### PR TITLE
ux: remove emoji from section headings on lineage.html

### DIFF
--- a/lineage.html
+++ b/lineage.html
@@ -178,7 +178,7 @@
     <main id="main-content" class="container" role="main">
         <!-- Introduction -->
         <section class="card">
-            <h2>🌳 Introduction: A Portrait of an Amazigh Lineage</h2>
+            <h2>Introduction: A Portrait of an Amazigh Lineage</h2>
             
             <div style="background: #FFFFFF; padding: 2rem; border-radius: 12px; margin: 2rem 0; box-shadow: 0 1px 3px rgba(0,0,0,0.08);">
                 <h3 style="text-align: center; color: #1E3A5F; margin-bottom: 1.5rem; font-size: 1.1rem; font-weight: 600;">Phylogenetic Heritage Overview</h3>
@@ -257,7 +257,7 @@ flowchart LR
 
         <!-- Paternal Ancestry -->
         <section class="card">
-            <h2>👨‍👦 The Paternal Ancestry: A Deep History of the Amazigh Y-Chromosome (E-PF2546)</h2>
+            <h2>The Paternal Ancestry: A Deep History of the Amazigh Y-Chromosome (E-PF2546)</h2>
             
             <div class="image-container">
                 <img src="img/E-PF2546-map.png" alt="E-M81 Berber Marker Distribution Across North Africa" style="width: 100%; height: auto; border-radius: 8px; box-shadow: var(--shadow);" loading="lazy" decoding="async" width="800" height="600">
@@ -313,7 +313,7 @@ flowchart LR
 
         <!-- Maternal Ancestry -->
         <section class="card">
-            <h2>👩‍👧 The Maternal Ancestry: A European Journey to Africa (H1-T16189C!)</h2>
+            <h2>The Maternal Ancestry: A European Journey to Africa (H1-T16189C!)</h2>
             
             <div class="image-container">
                 <img src="img/map-h-haplo.png" alt="H1 Haplogroup Distribution and Migration Patterns" style="width: 100%; height: auto; border-radius: 8px; box-shadow: var(--shadow);" loading="lazy" decoding="async" width="800" height="500">
@@ -515,7 +515,7 @@ flowchart LR
 
         <!-- Genetic Synthesis -->
         <section class="card">
-            <h2>🤝 Genetic Synthesis: The "H1 Enigma" and the Peopling of North Africa</h2>
+            <h2>Genetic Synthesis: The "H1 Enigma" and the Peopling of North Africa</h2>
             
             <div style="max-width: 600px; margin: 2rem auto;">
                 <div style="height: 300px;">


### PR DESCRIPTION
Closes #24

## Summary
- Removed 🌳, 👨‍👦, 👩‍👧, and 🤝 emojis from the four h2 section headings in `lineage.html`
- Headings now read with a clean, scholarly tone consistent with the research content
- No visual anchoring is lost — the CSS left-border accent on section cards still provides visual hierarchy

## Test plan
- [ ] Open lineage.html and verify headings display without emoji
- [ ] Verify "On This Page" TOC links still work (slugify strips emoji anyway)
- [ ] Check that heading styles are unchanged (color, size, weight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)