### PR TITLE
ux: expand 'On This Page' TOC by default on all pages

### DIFF
--- a/js/reading-aids.js
+++ b/js/reading-aids.js
@@ -43,11 +43,10 @@ document.addEventListener('DOMContentLoaded', function () {
     const toc = document.createElement('section');
     toc.className = 'card toc-card';
     toc.setAttribute('aria-label', 'Table of contents');
-    toc.classList.add('is-collapsed');
     toc.innerHTML = [
         '<div class="toc-header">',
         '<h3 class="toc-title">On This Page</h3>',
-        '<button type="button" class="toc-toggle" aria-expanded="false">Show sections</button>',
+        '<button type="button" class="toc-toggle" aria-expanded="true">Hide sections</button>',
         '</div>',
         '<ol class="toc-list"></ol>'
     ].join('');
@@ -85,9 +84,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
     if (tocToggle) {
         tocToggle.addEventListener('click', function () {
-            const isCollapsed = toc.classList.toggle('is-collapsed');
-            tocToggle.textContent = isCollapsed ? 'Show sections' : 'Hide sections';
-            tocToggle.setAttribute('aria-expanded', String(!isCollapsed));
+            const isExpanded = tocToggle.getAttribute('aria-expanded') === 'true';
+            toc.classList.toggle('is-collapsed', isExpanded);
+            tocToggle.textContent = isExpanded ? 'Show sections' : 'Hide sections';
+            tocToggle.setAttribute('aria-expanded', String(!isExpanded));
         });
     }
 


### PR DESCRIPTION
Closes #22

## Summary
- TOC now renders **expanded** on page load instead of hidden behind a "Show sections" button
- Toggle button label starts as "Hide sections" and flips correctly on click
- `aria-expanded` attribute is accurate from the first render

## Test plan
- [ ] Open lineage.html or genetics.html — TOC list is immediately visible without any click
- [ ] Click "Hide sections" — list collapses correctly
- [ ] Click "Show sections" — list re-expands
- [ ] Verify active section highlighting in TOC still updates on scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)