### PR TITLE
ux: fix awkward split heading in homepage hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,7 @@
                         <span class="home-hero-kicker">Genetic Research</span>
                         <div class="home-hero-kicker-line"></div>
                     </div>
-                    <h2 itemprop="headline" class="home-hero-title">Tracing an Ancient Amazigh Lineage through <span class="home-hero-accent">Genetic Analysis</span></h2>
+                    <h2 itemprop="headline" class="home-hero-title">Ancient Amazigh Lineage — <span class="home-hero-accent">A Genetic Analysis</span></h2>
                     <p class="text-large home-hero-copy">A comprehensive multi-disciplinary study examining the convergence of indigenous North African (E-PF2546) and European (H1-T16189C!) lineages within the Chtouka confederation of the Souss-Massa region.</p>
                     <div class="home-hero-actions">
                         <a href="start-here.html" class="btn btn-outline btn-outline-copper">Start Here (New Visitors)</a>


### PR DESCRIPTION
Closes #23

## Summary
- Old heading: **"Tracing an Ancient Amazigh Lineage through"** + `[gold]Genetic Analysis[/gold]`
  — wraps to 3+ lines with "through" orphaned, gold text appearing visually detached
- New heading: **"Ancient Amazigh Lineage —"** + `[gold]A Genetic Analysis[/gold]`
  — reads as a clean two-line phrase at any column width

## Test plan
- [ ] Open index.html at full width (1280px+) — heading displays in 1–2 lines, reads naturally
- [ ] Open at 768px — heading still wraps cleanly
- [ ] Verify JSON-LD `itemprop="headline"` still present on the h2

🤖 Generated with [Claude Code](https://claude.com/claude-code)