### PR TITLE
ux: shrink oversized header to compact horizontal strip

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -76,8 +76,10 @@
     
     <header role="banner">
         <div class="header-content">
+            <div class="header-text">
             <h1>Contact Me</h1>
             <p>Connect with a Fellow Heritage Enthusiast</p>
+            </div>
         </div>
     </header>
     <nav class="main-nav">

--- a/css/styles.css
+++ b/css/styles.css
@@ -104,38 +104,54 @@ header::before {
 .header-content {
     max-width: 1200px;
     margin: 0 auto;
-    padding: 1.25rem 4rem 0.9rem;
+    padding: 0.6rem 4rem;
     position: relative;
     z-index: 1;
-    text-align: center;
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
 }
 
 .header-content::before {
     content: '';
     display: block;
-    width: clamp(88px, 11vw, 124px);
-    height: clamp(88px, 11vw, 124px);
-    margin: 0 auto 0.5rem;
+    flex: 0 0 auto;
+    width: clamp(36px, 4vw, 48px);
+    height: clamp(36px, 4vw, 48px);
     background: url('../img/site-logo-mark.png') center / contain no-repeat;
+}
+
+.header-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
 }
 
 .header-content h1 {
     font-family: 'Space Grotesk', sans-serif;
-    font-size: clamp(1.5rem, 3vw, 2rem);
+    font-size: clamp(1rem, 2vw, 1.25rem);
     font-weight: 700;
     color: #2B4D63;
-    margin-bottom: 0.3rem;
+    margin: 0;
     letter-spacing: -0.02em;
     line-height: 1.2;
 }
 
 .header-content p {
-    font-size: clamp(0.875rem, 1.5vw, 1rem);
-    color: #6B7280;
-    max-width: 700px;
-    margin: 0 auto;
+    font-size: 0.8rem;
+    color: #9CA3AF;
+    margin: 0;
     font-weight: 400;
-    line-height: 1.5;
+    line-height: 1.3;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+@media (max-width: 768px) {
+    .header-content p {
+        display: none;
+    }
 }
 
 /* Navigation */

--- a/culture.html
+++ b/culture.html
@@ -94,8 +94,10 @@
     
     <header role="banner">
         <div class="header-content">
+            <div class="header-text">
             <h1>Souss-Massa Cultural Heritage</h1>
             <p>From Ancient Amazigh Confederations to Modern Traditions</p>
+            </div>
         </div>
     </header>
     <nav class="main-nav">

--- a/genetics.html
+++ b/genetics.html
@@ -94,8 +94,10 @@
     
     <header role="banner">
         <div class="header-content">
+            <div class="header-text">
             <h1>The DNA Revolution</h1>
             <p>How Genetics Rewrites Human History & Traces Ancient Migrations</p>
+            </div>
         </div>
     </header>
     <nav class="main-nav">

--- a/glossary.html
+++ b/glossary.html
@@ -59,8 +59,10 @@
 
     <header role="banner">
         <div class="header-content">
+            <div class="header-text">
             <h1>North African Amazigh Heritage</h1>
             <p>A Journey Through Time: Tracing Genetic, Historical, and Cultural Roots in the Souss-Massa</p>
+            </div>
         </div>
     </header>
     <nav class="main-nav">

--- a/index.html
+++ b/index.html
@@ -165,8 +165,10 @@
     
     <header role="banner">
         <div class="header-content">
+            <div class="header-text">
             <h1>North African Amazigh Heritage</h1>
             <p>A Journey Through Time: Tracing Genetic, Historical, and Cultural Roots in the Souss-Massa</p>
+            </div>
         </div>
     </header>
     <nav class="main-nav">

--- a/lineage.html
+++ b/lineage.html
@@ -142,8 +142,10 @@
     
     <header role="banner">
         <div class="header-content">
+            <div class="header-text">
             <h1>Complete Lineage Analysis</h1>
             <p>A Multi-Disciplinary Analysis of an Amazigh Lineage from the Souss-Massa</p>
+            </div>
         </div>
     </header>
     <nav class="main-nav">

--- a/maps-sites.html
+++ b/maps-sites.html
@@ -55,8 +55,10 @@
 
     <header role="banner">
         <div class="header-content">
+            <div class="header-text">
             <h1>North African Amazigh Heritage</h1>
             <p>A Journey Through Time: Tracing Genetic, Historical, and Cultural Roots in the Souss-Massa</p>
+            </div>
         </div>
     </header>
     <nav class="main-nav">

--- a/research.html
+++ b/research.html
@@ -67,8 +67,10 @@
 
     <header role="banner">
         <div class="header-content">
+            <div class="header-text">
             <h1>North African Amazigh Heritage</h1>
             <p>A Journey Through Time: Tracing Genetic, Historical, and Cultural Roots in the Souss-Massa</p>
+            </div>
         </div>
     </header>
     <nav class="main-nav">

--- a/start-here.html
+++ b/start-here.html
@@ -64,8 +64,10 @@
 
     <header role="banner">
         <div class="header-content">
+            <div class="header-text">
             <h1>North African Amazigh Heritage</h1>
             <p>A Journey Through Time: Tracing Genetic, Historical, and Cultural Roots in the Souss-Massa</p>
+            </div>
         </div>
     </header>
     <nav class="main-nav">


### PR DESCRIPTION
Closes #19

## Summary
- **Before:** Logo 88–124px centered above title and subtitle — ~280px tall header on every page
- **After:** Logo 36–48px inline-left, title+subtitle stacked right — ~65px compact strip
- CSS: `.header-content` switches from `text-align: center` block to `display: flex; align-items: center`
- All 9 HTML pages updated: h1+p wrapped in `.header-text` div for correct flex layout
- Subtitle hidden on mobile (< 768px) via `display: none` to save space

## Test plan
- [ ] Open any page — header is a compact horizontal strip, content starts ~200px sooner
- [ ] Verify logo image displays (left side, small)
- [ ] Check title (h1) reads correctly next to logo
- [ ] Verify mobile (< 768px) hides subtitle but keeps logo and title

🤖 Generated with [Claude Code](https://claude.com/claude-code)