### PR TITLE
ux: slim homepage — replace dense content sections with clean section nav cards

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -5117,3 +5117,66 @@ select:focus-visible {
         line-height: 1.3;
     }
 }
+
+/* ========================================
+   HOME PAGE — SECTION NAVIGATION CARDS
+   ======================================== */
+
+.home-section-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.5rem;
+    margin-bottom: 3rem;
+}
+
+.home-section-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    border-top: 3px solid var(--primary-terracotta);
+}
+
+.home-section-kicker {
+    font-size: 0.72rem;
+    color: var(--primary-terracotta);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-weight: 600;
+}
+
+.home-section-title {
+    font-size: 1.3rem;
+    font-weight: 700;
+    margin: 0;
+    line-height: 1.3;
+    color: var(--text-primary);
+}
+
+.home-section-title a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.home-section-title a:hover {
+    color: var(--primary-terracotta);
+}
+
+.home-section-copy {
+    color: var(--text-secondary);
+    font-size: 0.93rem;
+    line-height: 1.65;
+    flex: 1;
+    margin: 0;
+}
+
+.home-section-cta {
+    align-self: flex-start;
+    margin-top: 0.5rem;
+    font-size: 0.88rem;
+}
+
+@media (max-width: 768px) {
+    .home-section-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@
                     <div class="home-hero-actions">
                         <a href="start-here.html" class="btn btn-outline btn-outline-copper">Start Here (New Visitors)</a>
                         <a href="lineage.html" class="btn btn-copper">View Complete Analysis</a>
-                        <a href="#souss-massa" class="btn btn-outline btn-outline-copper">Explore Region</a>
+                        <a href="culture.html" class="btn btn-outline btn-outline-copper">Explore Culture</a>
                     </div>
                 </div>
                 <div class="home-hero-media">
@@ -219,258 +219,32 @@
             </div>
         </section>
 
-        <!-- Souss-Massa Overview -->
-        <section id="souss-massa" class="card" itemscope itemtype="https://schema.org/Place">
-            <h2 itemprop="name">The Souss-Massa Region</h2>
-            
-            <!-- Souss-Massa Landscape Image -->
-            <div class="featured-image" style="margin: 2rem 0;">
-                <img src="img/souss-valley-landscape.jpg" alt="Souss-Massa Valley panoramic landscape showing Atlas Mountains, argan forests, and traditional Amazigh territory in southwestern Morocco" width="1200" height="450" style="width: 100%; height: 450px; object-fit: cover; border-radius: 16px; box-shadow: 0 10px 30px rgba(0,0,0,0.2);" loading="lazy">
-                <p style="text-align: center; margin-top: 1rem; font-style: italic; color: #666; font-size: 0.95rem;">
-                    <strong>Souss-Massa Region:</strong> Traditional territory of the Chtouka confederation between the Atlas Mountains and Atlantic Ocean
-                </p>
-            </div>
-            
-            <meta itemprop="addressCountry" content="MA">
-            <meta itemprop="addressRegion" content="Souss-Massa">
-            <div itemprop="geo" itemscope itemtype="https://schema.org/GeoCoordinates">
-                <meta itemprop="latitude" content="30.3333">
-                <meta itemprop="longitude" content="-9.2333">
-            </div>
-            
-            <p class="text-large mb-2">
-                The <strong>Souss-Massa</strong> is a fertile region in southwestern Morocco, nestled between the High Atlas Mountains and the Atlantic Ocean. This ancient valley has been the heartland of Amazigh civilization for millennia, serving as a crossroads of cultures and a center of indigenous resistance and autonomy.
-            </p>
-
-            <section class="home-map-feature" aria-labelledby="maghreb-map-title">
-                <div class="home-map-grid">
-                    <div>
-                        <span class="home-map-kicker">Regional Context</span>
-                        <h3 id="maghreb-map-title" class="home-map-title">Maghreb Geographic Frame</h3>
-                        <p class="home-map-copy">This unlabeled map places the Souss-Massa homeland within its wider North African setting. It helps orient the regional scope of lineage movements discussed across this site, from Atlantic Morocco to neighboring Maghreb zones.</p>
-                    </div>
-                    <figure class="home-map-figure">
-                        <img src="img/map-maghreb.png" alt="Unlabeled map of the Maghreb region used as geographic context for Amazigh lineage analysis" class="home-map-image" loading="lazy">
-                        <figcaption class="home-map-caption">Unlabeled Maghreb map for geographic orientation and migration context.</figcaption>
-                    </figure>
-                </div>
-            </section>
-
-            <div class="grid" style="gap: 2rem; align-items: start;">
-                <div>
-                    <h3>Geography &amp; Climate</h3>
-                    <p>The Souss Valley stretches approximately 230 kilometers from the Atlas foothills to the Atlantic coast. Fed by the Souss River, this fertile plain contrasts sharply with the arid landscapes of the surrounding mountains and desert.</p>
-                    
-                    <h3>The Argan Ecosystem</h3>
-                    <p>Home to the endemic Argan tree (Argania spinosa), the region supports a unique ecosystem found nowhere else on Earth. The Argan forest has sustained local Amazigh communities for thousands of years.</p>
-                </div>
-                
-                <div>
-                    <img src="img/atlas-mountains.jpg" alt="High Atlas Mountains range overlooking the Souss Valley in Morocco, showing the geographic context of Amazigh Chtouka territory" width="800" height="280" style="width: 100%; height: 280px; object-fit: cover; border-radius: 12px; box-shadow: 0 8px 24px rgba(0,0,0,0.15); margin-bottom: 1.5rem;" loading="lazy">
-                    
-                    <h3>Historical Significance</h3>
-                    <p>The Souss was the birthplace of the great Berber dynasties - the Almoravids and Almohads - who ruled an empire stretching from Spain to sub-Saharan Africa during the medieval period.</p>
-                    
-                    <h3>Cultural Heritage</h3>
-                    <p>The region remains the stronghold of <em>Tachelhit</em> (Shilha), the most widely spoken Amazigh language, with a rich tradition of oral poetry, music, and customary law that has survived for centuries.</p>
-                </div>
-            </div>
-
-            <div class="argan-landscape" style="margin: 2rem 0;">
-                <img src="img/argan-forest.jpg" alt="Ancient argan forest ecosystem (Argania spinosa) in Souss Valley, Morocco, unique UNESCO biosphere reserve sustaining Amazigh communities for millennia" width="1200" height="300" style="width: 100%; height: 300px; object-fit: cover; border-radius: 12px; box-shadow: 0 8px 24px rgba(0,0,0,0.15);" loading="lazy">
-                <p style="text-align: center; margin-top: 1rem; font-style: italic; color: #666; font-size: 0.95rem;">
-                    <strong>Argan Ecosystem:</strong> The unique Argania spinosa trees that have sustained Amazigh communities for millennia
-                </p>
-            </div>
-        </section>
-
-        <!-- Lineage Overview -->
-        <section class="card">
-            <h2>A Tale of Two Ancestries</h2>
-            
-            <!-- Genetic Heritage Visual -->
-            <div class="heritage-visual" style="margin: 2rem 0; display: grid; grid-template-columns: 1fr 1fr; gap: 2rem;">
-                <div>
-                    <!-- 
-                    MIDJOURNEY PROMPT FOR PATERNAL LINE:
-                    "Ancient North African berber warrior in traditional dress, iron age morocco, sahara desert background, 
-                    DNA helix overlaid in blue, scientific illustration meets historical art, warm earth tones, 
-                    detailed portrait, national geographic style --ar 3:4 --v 6"
-                    
-                    Replace with: <img src="img/paternal-heritage.jpg" alt="Paternal E-PF2546 Heritage">
-                    -->
-                    <img src="img/paternal-heritage.jpg" alt="Paternal E-PF2546 Y-DNA heritage visualization showing North African Amazigh lineage from Iron Age Morocco, representing indigenous Berber genetic marker" width="600" height="400" style="width: 100%; height: 400px; object-fit: cover; border-radius: 16px; box-shadow: 0 10px 30px rgba(0,0,0,0.2);" loading="lazy">
-                </div>
-                <div>
-                    <img src="img/maternal-heritage.jpg" alt="Maternal H1-T16189C mtDNA heritage visualization showing European genetic lineage that migrated to North Africa 10,000 years ago during Neolithic period" width="600" height="400" style="width: 100%; height: 400px; object-fit: cover; border-radius: 16px; box-shadow: 0 10px 30px rgba(0,0,0,0.2);" loading="lazy">
-                </div>
-            </div>
-            
-            <p class="text-large">
-                This genetic heritage tells the story of two distinct ancestral streams converging in the heart of Morocco:
-            </p>
-            
-            <div class="grid">
-                <div class="card interactive-card" style="border-left: 4px solid var(--primary-color);">
-                    <h3>Paternal Line: <a href="lineage.html#paternal" style="color: inherit; text-decoration: underline;">E-PF2546</a></h3>
-                    <p><strong>Origin:</strong> Indigenous North African (Amazigh)</p>
-                    <p><strong>Age:</strong> ~2,300 years (~300 BCE formation per YFull)</p>
-                    <p><strong>Story:</strong> A lineage that expanded dramatically across the Maghreb during the Iron Age, coinciding with the rise of the Mauritanian kingdoms and becoming the defining Y-chromosome of the <a href="culture.html">Berber people</a>. Whole Y-chromosome analysis (D'Atanasio et al. 2018) revealed the parent E-M81 clade underwent a surprisingly recent expansion.</p>
-                </div>
-                
-                <div class="card interactive-card" style="border-left: 4px solid var(--secondary-color);">
-                    <h3>Maternal Line: <a href="lineage.html#maternal" style="color: inherit; text-decoration: underline;">H1-T16189C!</a></h3>
-                    <p><strong>Origin:</strong> Prehistoric European migration via Gibraltar</p>
-                    <p><strong>Age:</strong> ~11,400 years in North Africa (Early Holocene; Ottoni et al. 2010)</p>
-                    <p><strong>Story:</strong> A maternal lineage that crossed from Iberia during the early Holocene climatic optimum, part of the first <a href="genetics.html">Neolithic farmer migrations</a> confirmed by ancient DNA (Villalba-Mouco et al. 2023, <em>Nature</em>), becoming deeply embedded in the North African gene pool and evolving local subclades (H1v, H1w, H1x).</p>
-                </div>
-            </div>
-
-            <div class="text-center mb-2">
-                <a href="lineage.html" class="btn">Read the Complete Analysis</a>
-            </div>
-        </section>
-
-        <!-- Key Findings -->
-        <section class="card">
-            <!-- DNA Analysis Banner Image -->
-            <div style="margin: -2.5rem -2.5rem 2rem -2.5rem; position: relative; overflow: hidden; border-radius: 6px 6px 0 0;">
-                <img src="img/dna-analysis-banner.jpg" alt="DNA analysis laboratory showing genetic sequencing technology used in Amazigh lineage research and haplogroup identification" width="1200" height="200" style="width: 100%; height: 200px; object-fit: cover; opacity: 0.2;" loading="lazy">
-                <div style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; background: linear-gradient(135deg, rgba(212, 166, 41, 0.85) 0%, rgba(228, 194, 88, 0.75) 100%); display: flex; align-items: center; justify-content: center;">
-                    <div style="color: white; text-align: center;">
-                        <div style="font-size: 1.4rem; margin-bottom: 0.5rem; font-weight: 700; letter-spacing: 0.04em;">DNA</div>
-                        <div style="font-family: 'Space Grotesk', sans-serif; font-size: 1.8rem; font-weight: 700;">Key Genetic Findings</div>
-                    </div>
-                </div>
-            </div>
-            
-            <h2>Key Genetic Findings</h2>
-            
-            <!-- Recent Updates Banner -->
-            <div style="background: linear-gradient(135deg, rgba(212, 166, 41, 0.1) 0%, rgba(228, 194, 88, 0.15) 100%); border: 2px solid #D4A629; border-left: 4px solid #D4A629; padding: 1.5rem; border-radius: 6px; margin-bottom: 2rem;">
-                <div style="display: flex; align-items: start; gap: 1rem;">
-                    <div style="font-size: 0.85rem; flex-shrink: 0; font-weight: 700; color: #2F7FA5; text-transform: uppercase; letter-spacing: 0.05em;">Update</div>
-                    <div>
-                        <h3 style="margin: 0 0 0.75rem 0; font-size: 1.1rem; color: #2B4D63; font-weight: 700;">Latest Research Updates (July 2026)</h3>
-                        <div style="font-size: 0.95rem; line-height: 1.7; color: #4B5563;">
-                            <p style="margin: 0 0 0.5rem 0;"><strong style="color: #D4A629;">E-M81 re-dated:</strong> D'Atanasio et al. (2018, <em>Scientific Reports</em>) revealed a surprisingly recent TMRCA of ~2,000-3,000 years ago using whole Y-chromosome sequencing. E-PF2546 formation estimated at ~2,300 years BP per YFull.</p>
-                            <p style="margin: 0 0 0.5rem 0;"><strong style="color: #D4A629;">Ancient DNA breakthroughs:</strong> Villalba-Mouco et al. (2023, <em>Nature</em>) confirmed Iberian Neolithic migrants reached Morocco. Lipson et al. (2025, <em>Nature</em>) showed strong indigenous continuity in eastern Maghreb Neolithic communities (Algeria/Tunisia), with limited external admixture. Salem et al. (2025, <em>Nature</em>) revealed ancestral Green Sahara lineages from ~7,000 ya in Libya.</p>
-                            <p style="margin: 0 0 0.5rem 0;"><strong style="color: #D4A629;">H1 mtDNA confirmed:</strong> Colombo et al. (2025, <em>Scientific Reports</em>) surveyed 733 modern and 43 ancient mitogenomes, confirming North African-specific H1 subclades (H1v, H1w, H1x).</p>
-                            <p style="margin: 0;"><strong style="color: #D4A629;">Technological advances:</strong> Consumer ancestry tests from ~$50-100; institutional whole-genome sequencing at ~$200/genome.</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Category</th>
-                        <th>Result</th>
-                        <th>Significance</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td><strong>Paternal Y-DNA</strong></td>
-                        <td>E-PF2546</td>
-                        <td>Ancient Amazigh "Berber marker" with Iron Age expansion (~2,300 years ago per YFull; parent E-M81 TMRCA debated at ~2,000-4,200 ya)</td>
-                    </tr>
-                    <tr>
-                        <td><strong>Maternal mtDNA</strong></td>
-                        <td>H1-T16189C!</td>
-                        <td>Prehistoric European lineage, Early Holocene arrival (~11,400 years ago; Ottoni et al. 2010)</td>
-                    </tr>
-                    <tr>
-                        <td><strong>Autosomal DNA</strong></td>
-                        <td>100% Middle East & North Africa</td>
-                        <td>Complete Maghrebi genetic signature</td>
-                    </tr>
-                    <tr>
-                        <td><strong>Tribal Affiliation</strong></td>
-                        <td>Chtouka Confederation</td>
-                        <td>Indigenous Souss-Massa confederation</td>
-                    </tr>
-                </tbody>
-            </table>
-        </section>
-
-        <!-- Historical Timeline Preview -->
-        <section class="card">
-            <h2>Timeline of Heritage</h2>
-            
-            <div style="position: relative; padding: 2rem 0;">
-                <!-- Timeline line -->
-                <div style="position: absolute; left: 50%; top: 0; bottom: 0; width: 3px; background: linear-gradient(180deg, #D4A629 0%, #E4C258 50%, #5FA98E 100%); transform: translateX(-50%);"></div>
-                
-                <!-- Timeline items -->
-                <div style="display: flex; flex-direction: column; gap: 2rem;">
-                    <!-- Item 1 - Left -->
-                    <div style="display: grid; grid-template-columns: 1fr auto 1fr; gap: 2rem; align-items: center;">
-                        <div style="text-align: right;">
-                            <div style="background: #FFF; border: 2px solid #D4A629; padding: 1.5rem; border-radius: 6px; box-shadow: 0 2px 8px rgba(0,0,0,0.08);">
-                                <div style="font-family: 'Space Grotesk', sans-serif; font-weight: 700; color: #D4A629; font-size: 1.1rem; margin-bottom: 0.5rem;">~11,400 years ago</div>
-                                <div style="font-size: 0.95rem; color: #4B5563; line-height: 1.6;">Maternal H1 lineage arrives from Iberia during early Holocene migrations (Ottoni et al. 2010)</div>
-                            </div>
-                        </div>
-                        <div style="width: 20px; height: 20px; background: #D4A629; border: 4px solid #FFF; border-radius: 50%; box-shadow: 0 0 0 2px #D4A629; z-index: 2;"></div>
-                        <div></div>
-                    </div>
-                    
-                    <!-- Item 2 - Right -->
-                    <div style="display: grid; grid-template-columns: 1fr auto 1fr; gap: 2rem; align-items: center;">
-                        <div></div>
-                        <div style="width: 20px; height: 20px; background: #E4C258; border: 4px solid #FFF; border-radius: 50%; box-shadow: 0 0 0 2px #E4C258; z-index: 2;"></div>
-                        <div style="text-align: left;">
-                            <div style="background: #FFF; border: 2px solid #E4C258; padding: 1.5rem; border-radius: 6px; box-shadow: 0 2px 8px rgba(0,0,0,0.08);">
-                                <div style="font-family: 'Space Grotesk', sans-serif; font-weight: 700; color: #E4C258; font-size: 1.1rem; margin-bottom: 0.5rem;">~2,300 years ago (~300 BCE)</div>
-                                <div style="font-size: 0.95rem; color: #4B5563; line-height: 1.6;">Paternal E-PF2546 lineage forms during height of Mauretanian kingdoms and Carthaginian era (YFull YTree)</div>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <!-- Item 3 - Left -->
-                    <div style="display: grid; grid-template-columns: 1fr auto 1fr; gap: 2rem; align-items: center;">
-                        <div style="text-align: right;">
-                            <div style="background: #FFF; border: 2px solid #5FA98E; padding: 1.5rem; border-radius: 6px; box-shadow: 0 2px 8px rgba(0,0,0,0.08);">
-                                <div style="font-family: 'Space Grotesk', sans-serif; font-weight: 700; color: #5FA98E; font-size: 1.1rem; margin-bottom: 0.5rem;">1040-1269 CE</div>
-                                <div style="font-size: 0.95rem; color: #4B5563; line-height: 1.6;">Souss becomes heartland of Almoravid and Almohad Berber empires</div>
-                            </div>
-                        </div>
-                        <div style="width: 20px; height: 20px; background: #5FA98E; border: 4px solid #FFF; border-radius: 50%; box-shadow: 0 0 0 2px #5FA98E; z-index: 2;"></div>
-                        <div></div>
-                    </div>
-                    
-                    <!-- Item 4 - Right -->
-                    <div style="display: grid; grid-template-columns: 1fr auto 1fr; gap: 2rem; align-items: center;">
-                        <div></div>
-                        <div style="width: 20px; height: 20px; background: #2F7FA5; border: 4px solid #FFF; border-radius: 50%; box-shadow: 0 0 0 2px #2F7FA5; z-index: 2;"></div>
-                        <div style="text-align: left;">
-                            <div style="background: #FFF; border: 2px solid #2F7FA5; padding: 1.5rem; border-radius: 6px; box-shadow: 0 2px 8px rgba(0,0,0,0.08);">
-                                <div style="font-family: 'Space Grotesk', sans-serif; font-weight: 700; color: #2F7FA5; font-size: 1.1rem; margin-bottom: 0.5rem;">1269-1912 CE</div>
-                                <div style="font-size: 0.95rem; color: #4B5563; line-height: 1.6;">Era of Bled al-Siba - Chtouka confederation maintains political autonomy</div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-
-
-        <!-- Call to Action -->
-        <section class="card text-center">
-            <h2>Explore the Full Story</h2>
-            <p class="text-large mb-2">
-                Dive deep into the comprehensive analysis combining <a href="genetics.html">genetics</a>, archaeology, linguistics, and anthropology to understand how these two ancient lineages converged in the <a href="#souss-massa">Souss-Massa valley</a>.
-            </p>
-            <div style="display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; margin-top: 2rem;">
-                <a href="lineage.html" class="btn">Complete Lineage Analysis</a>
-                <a href="genetics.html" class="btn">DNA Revolution Science</a>
-                <a href="culture.html" class="btn">Cultural Heritage</a>
-                <a href="gemeni-infograph.html" class="btn">Visual Infographic</a>
-                <a href="contact.html" class="btn btn-outline">Contact Us for Research</a>
-            </div>
+        <!-- Section Navigation Cards -->
+        <section class="home-section-grid" aria-label="Explore the site">
+            <article class="card home-section-card">
+                <div class="home-section-kicker">Genetics &amp; DNA</div>
+                <h2 class="home-section-title"><a href="lineage.html">Lineage History</a></h2>
+                <p class="home-section-copy">E-PF2546 paternal and H1-T16189C! maternal haplogroups — 11,000+ years of ancestry traced through multi-disciplinary analysis of the Chtouka confederation.</p>
+                <a href="lineage.html" class="btn btn-copper home-section-cta">Read the Analysis</a>
+            </article>
+            <article class="card home-section-card">
+                <div class="home-section-kicker">Science</div>
+                <h2 class="home-section-title"><a href="genetics.html">The DNA Revolution</a></h2>
+                <p class="home-section-copy">How ancient DNA and modern genomics are rewriting the story of North African prehistory and human migration across the Maghreb.</p>
+                <a href="genetics.html" class="btn btn-outline btn-outline-copper home-section-cta">Explore Genetics</a>
+            </article>
+            <article class="card home-section-card">
+                <div class="home-section-kicker">Heritage</div>
+                <h2 class="home-section-title"><a href="culture.html">Cultural Heritage</a></h2>
+                <p class="home-section-copy">Tachelhit language, Agadir granaries, Argan oil traditions — the living culture of the Chtouka confederation in the Souss-Massa valley.</p>
+                <a href="culture.html" class="btn btn-outline btn-outline-copper home-section-cta">Explore Culture</a>
+            </article>
+            <article class="card home-section-card">
+                <div class="home-section-kicker">Papers</div>
+                <h2 class="home-section-title"><a href="research.html">Research &amp; Sources</a></h2>
+                <p class="home-section-copy">Peer-reviewed papers, ancient DNA studies, and academic sources that underpin every claim on this site.</p>
+                <a href="research.html" class="btn btn-outline btn-outline-copper home-section-cta">Browse Research</a>
+            </article>
         </section>
     </main>
 


### PR DESCRIPTION
Closes #20

## Summary
Removed 4 heavy content sections that buried first-time visitors before they understood the site:
- ~~Souss-Massa Region~~ (3 large images, geography, climate, map) → content lives on `culture.html`
- ~~A Tale of Two Ancestries~~ (2 hero images + nested cards) → content lives on `lineage.html`
- ~~Key Genetic Findings~~ (research update banner + full data table) → content lives on `lineage.html`
- ~~Timeline of Heritage~~ (4-item alternating timeline) → content lives on `lineage.html`

**Replaced with:** a clean `2×2` section navigation card grid linking to the 4 main pages, each with a kicker label, heading, 2-sentence description, and CTA button.

Homepage went from **483 → 257 lines** (-47%). The hero card is preserved intact, with the "Explore Region" button (dead `#souss-massa` anchor) updated to `culture.html`.

Added `.home-section-grid` and `.home-section-card` CSS (responsive: 2-col → 1-col at 768px).

## Test plan
- [ ] Open index.html — page ends well above the fold after scrolling past hero + 4 cards
- [ ] All 4 nav cards link to correct subpages
- [ ] Verify hero buttons ("Start Here", "View Complete Analysis", "Explore Culture") all work
- [ ] Check 768px — cards stack to 1 column

🤖 Generated with [Claude Code](https://claude.com/claude-code)