### PR TITLE
design: Literata for reading, Archivo for chrome (#56)

### DIFF
--- a/changelog/unreleased/design-typography.md
+++ b/changelog/unreleased/design-typography.md
@@ -1,0 +1,7 @@
+### Changed
+- New type pairing: Literata for long-form reading, Archivo for headings and chrome, IBM Plex Mono kept for haplogroup notation. Inter and Space Grotesk are the two faces most associated with machine-generated layout, and Inter is a UI face carrying 2,242 words of prose on lineage.html (#56)
+- Body text set at 17px/1.7 with a 72ch measure on running prose
+- Fonts now load from a `<link>` in `<head>` instead of a render-blocking `@import` at the top of the stylesheet
+
+### Fixed
+- `.region-map`, `.genetic-diagram` and `.phylogenetic-tree` labels asked for `Lexend`, which was never loaded — a silent fallback to the browser default

--- a/contact.html
+++ b/contact.html
@@ -42,6 +42,10 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     
     <!-- CSS -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
+         @import-ed from the stylesheet, which was render-blocking. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="css/styles.css">
     
     <!-- Structured Data - JSON-LD -->

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,7 +1,6 @@
 /* Scientific Research Portal - DNA Lineage Heritage */
 
 /* Import Professional Fonts */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap');
 
 :root {
     /* Amazigh Earth-Tone Palette — no blues (issue #36) */
@@ -77,8 +76,9 @@ html {
 }
 
 body {
-    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    line-height: 1.65;
+    font-family: 'Literata', Georgia, 'Times New Roman', serif;
+    font-size: 17px;
+    line-height: 1.7;
     color: var(--text-primary);
     background: var(--background);
     -webkit-font-smoothing: antialiased;
@@ -125,7 +125,7 @@ header {
 }
 
 .site-brand-name {
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
     font-weight: 700;
     font-size: clamp(0.95rem, 1.6vw, 1.1rem);
     letter-spacing: -0.01em;
@@ -138,7 +138,7 @@ header {
 
 /* The <h1> now lives in <main>, so the header can stay constant across pages. */
 .page-title {
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
     font-size: clamp(1.9rem, 4.2vw, 2.6rem);
     font-weight: 700;
     line-height: 1.12;
@@ -156,7 +156,7 @@ header {
 }
 
 .header-content h1 {
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
     font-size: clamp(1rem, 2vw, 1.25rem);
     font-weight: 700;
     color: #3E2723;
@@ -438,7 +438,7 @@ main > .card:first-child {
 }
 
 .card h2 {
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
     color: var(--primary-dark);
     margin-bottom: 1.5rem;
     font-size: 2rem;
@@ -453,7 +453,7 @@ main > .card:first-child {
 }
 
 .card h3 {
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
     color: var(--primary-navy);
     margin: 2rem 0 1rem;
     font-size: 1.5rem;
@@ -771,7 +771,7 @@ main > .card:first-child {
 .data-table th {
     padding: 1.25rem 1.5rem;
     text-align: left;
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
     font-weight: 600;
     font-size: 0.875rem;
     color: #FFFFFF;
@@ -1106,7 +1106,7 @@ footer a:hover {
 }
 
 .filter-section h3 {
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
     font-size: 1.25rem;
     font-weight: 600;
     color: var(--primary-dark);
@@ -1472,7 +1472,7 @@ footer a:hover {
 
 /* Geographic and genetic visualization styles */
 .region-map text, .genetic-diagram text, .phylogenetic-tree text {
-    font-family: 'Lexend', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
 }
 
 .genetic-diagram {
@@ -1982,7 +1982,7 @@ select:focus {
     color: #fff;
     margin: 0;
     font-size: clamp(1.6rem, 3vw, 2rem);
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
     text-wrap: balance;
 }
 
@@ -2011,7 +2011,7 @@ select:focus {
 }
 
 .genetics-stat-value {
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
     font-size: clamp(2rem, 4vw, 2.6rem);
     font-weight: 700;
     color: var(--primary-dark);
@@ -3202,7 +3202,7 @@ select:focus {
 }
 
 .discovery-card h4 {
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
     color: var(--primary-dark);
     font-size: 1.15rem;
     font-weight: 600;
@@ -3245,7 +3245,7 @@ select:focus {
 
 .tech-card h4,
 .method-card h4 {
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
     color: var(--primary-navy);
     margin-bottom: 1rem;
     font-size: 1.2rem;
@@ -3298,7 +3298,7 @@ select:focus {
 }
 
 .evolution-content h3 {
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
     color: var(--primary-dark);
     margin-bottom: 0.75rem;
 }
@@ -3328,7 +3328,7 @@ select:focus {
 }
 
 .haplogroup-type h4 {
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
     color: var(--primary-navy);
     font-size: 1.3rem;
     margin-bottom: 0.75rem;
@@ -3378,7 +3378,7 @@ select:focus {
 }
 
 .migration-content h4 {
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
     color: var(--primary-dark);
     font-size: 1.2rem;
     margin-bottom: 0.75rem;
@@ -3473,7 +3473,7 @@ select:focus {
 }
 
 .period-content h3 {
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
     color: var(--primary-dark);
     font-size: 1.4rem;
     margin-bottom: 0.75rem;
@@ -3513,7 +3513,7 @@ select:focus {
 }
 
 .impact-point h4 {
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
     color: var(--primary-navy);
     margin-bottom: 1rem;
 }
@@ -3798,7 +3798,7 @@ select:focus {
 .related-link-card h4 {
     margin: 0 0 0.5rem;
     color: var(--primary-dark);
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
     font-size: 1rem;
 }
 
@@ -4008,7 +4008,7 @@ select:focus {
     color: #3E2723;
     margin-bottom: 0.75rem;
     line-height: 1.4;
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
 }
 
 .discovery-summary {
@@ -4165,7 +4165,7 @@ select:focus {
 .glossary-term-title {
     margin: 0 0 0.6rem;
     color: #3E2723;
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
 }
 
 .glossary-term-copy {
@@ -4828,7 +4828,7 @@ main#main-content.has-reading-aids {
     margin: 0 0 0.65rem;
     font-size: 1.35rem;
     color: #3E2723;
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
 }
 
 .home-map-copy {
@@ -5383,3 +5383,45 @@ select:focus-visible {
 }
 
 .sourcing-note strong { color: var(--text-primary); }
+
+/* #56 — Literata is a reading face, so give running text a real measure.
+   Applies to prose only: tables, grids and diagrams set their own width. */
+.card > p,
+.card > ul,
+.card > ol {
+    max-width: 72ch;
+}
+
+.card > p + p { margin-top: 0.9rem; }
+
+/* Headings stay on the grotesque so the contrast between reading and chrome
+   carries meaning: prose is Literata, labels and structure are Archivo. */
+.home-section-kicker,
+.toc-card .toc-title,
+.page-updated,
+.breadcrumb {
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.page-updated { font-family: 'IBM Plex Mono', ui-monospace, monospace; }
+
+/* Chrome takes the grotesque, prose takes the serif. The contrast is the
+   point: what you read is Literata, what you navigate by is Archivo. */
+.nav-container a,
+.toc-list a,
+.btn,
+.footer-nav a,
+.site-brand-name,
+.home-section-cta,
+.hero-secondary-link,
+.meta-pill,
+th {
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
+}
+
+/* On the landing page the revision date is a footnote, not a byline. */
+.page-updated-footer {
+    margin: 2.5rem 0 0;
+    padding-top: 1.25rem;
+    border-top: 1px solid var(--border);
+}

--- a/culture.html
+++ b/culture.html
@@ -41,6 +41,10 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net">
     
     <!-- CSS and Scripts -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
+         @import-ed from the stylesheet, which was render-blocking. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="css/styles.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
     <script src="js/reading-aids.js" defer></script>

--- a/genetics.html
+++ b/genetics.html
@@ -41,6 +41,10 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net">
     
     <!-- CSS and Scripts -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
+         @import-ed from the stylesheet, which was render-blocking. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="css/styles.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
     <script src="js/reading-aids.js" defer></script>

--- a/glossary.html
+++ b/glossary.html
@@ -40,6 +40,10 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <!-- CSS -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
+         @import-ed from the stylesheet, which was render-blocking. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="css/styles.css">
 
     <!-- Structured Data - JSON-LD -->

--- a/index.html
+++ b/index.html
@@ -68,6 +68,10 @@
     <link rel="preload" as="image" href="img/hero-dna-morocco.webp" fetchpriority="high">
 
     <!-- CSS and Scripts -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
+         @import-ed from the stylesheet, which was render-blocking. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="css/styles.css">
     <script src="js/reading-aids.js" defer></script>
     
@@ -191,7 +195,6 @@
                         <div class="home-hero-kicker-line"></div>
                     </div>
                     <h1 itemprop="headline" class="home-hero-title">Ancient Amazigh Lineage — <span class="home-hero-accent">A Genetic Analysis</span></h1>
-        <p class="page-updated">Last updated: 6 September 2026</p>
                     <p class="text-large home-hero-copy">A comprehensive multi-disciplinary study examining the convergence of indigenous North African (E-PF2546) and European (H1-T16189C!) lineages within the Chtouka confederation of the Souss-Massa region.</p>
                     <div class="home-hero-actions">
                         <a href="lineage.html" class="btn btn-copper">Read the analysis</a>
@@ -235,6 +238,7 @@
                 <a href="research.html" class="btn btn-outline btn-outline-copper home-section-cta">Browse Research</a>
             </article>
         </section>
+        <p class="page-updated page-updated-footer">Last updated: 6 September 2026</p>
     </main>
 
     <footer role="contentinfo">

--- a/limitations.html
+++ b/limitations.html
@@ -40,6 +40,10 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <!-- CSS -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
+         @import-ed from the stylesheet, which was render-blocking. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="css/styles.css">
 
     <!-- Structured Data - JSON-LD -->

--- a/lineage.html
+++ b/lineage.html
@@ -58,6 +58,10 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net">
     
     <!-- CSS and Scripts -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
+         @import-ed from the stylesheet, which was render-blocking. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="css/styles.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
     <script src="js/reading-aids.js" defer></script>

--- a/maps-sites.html
+++ b/maps-sites.html
@@ -33,6 +33,10 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
+         @import-ed from the stylesheet, which was render-blocking. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="css/styles.css">
 
     <script type="application/ld+json">

--- a/research.html
+++ b/research.html
@@ -40,6 +40,10 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <!-- CSS -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
+         @import-ed from the stylesheet, which was render-blocking. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="css/styles.css">
 
     <!-- Structured Data - JSON-LD -->

--- a/research/amazigh-genomic-heterogeneity-2024.html
+++ b/research/amazigh-genomic-heterogeneity-2024.html
@@ -40,6 +40,10 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <!-- CSS -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
+         @import-ed from the stylesheet, which was render-blocking. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="../css/styles.css">
     <script src="../js/reading-aids.js" defer></script>
 

--- a/research/e-m183-recent-origin-2018.html
+++ b/research/e-m183-recent-origin-2018.html
@@ -40,6 +40,10 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <!-- CSS -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
+         @import-ed from the stylesheet, which was render-blocking. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="../css/styles.css">
     <script src="../js/reading-aids.js" defer></script>
 

--- a/research/eastern-maghreb-neolithic-continuity-2025.html
+++ b/research/eastern-maghreb-neolithic-continuity-2025.html
@@ -41,6 +41,10 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <!-- CSS -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
+         @import-ed from the stylesheet, which was render-blocking. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="../css/styles.css">
     <script src="../js/reading-aids.js" defer></script>
 

--- a/research/green-sahara-ancient-dna-2025.html
+++ b/research/green-sahara-ancient-dna-2025.html
@@ -40,6 +40,10 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <!-- CSS -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
+         @import-ed from the stylesheet, which was render-blocking. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="../css/styles.css">
     <script src="../js/reading-aids.js" defer></script>
 

--- a/research/neolithic-iberia-morocco-2023.html
+++ b/research/neolithic-iberia-morocco-2023.html
@@ -40,6 +40,10 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <!-- CSS -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
+         @import-ed from the stylesheet, which was render-blocking. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="../css/styles.css">
     <script src="../js/reading-aids.js" defer></script>
 

--- a/research/north-africa-demographic-history-2024.html
+++ b/research/north-africa-demographic-history-2024.html
@@ -40,6 +40,10 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <!-- CSS -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
+         @import-ed from the stylesheet, which was render-blocking. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="../css/styles.css">
     <script src="../js/reading-aids.js" defer></script>
 

--- a/research/north-africa-maternal-diversity-2026.html
+++ b/research/north-africa-maternal-diversity-2026.html
@@ -41,6 +41,10 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <!-- CSS -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
+         @import-ed from the stylesheet, which was render-blocking. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="../css/styles.css">
     <script src="../js/reading-aids.js" defer></script>
 

--- a/research/north-african-mitogenomes-2025.html
+++ b/research/north-african-mitogenomes-2025.html
@@ -40,6 +40,10 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <!-- CSS -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
+         @import-ed from the stylesheet, which was render-blocking. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="../css/styles.css">
     <script src="../js/reading-aids.js" defer></script>
 

--- a/research/punic-genetic-diversity-2025.html
+++ b/research/punic-genetic-diversity-2025.html
@@ -31,6 +31,10 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
+         @import-ed from the stylesheet, which was render-blocking. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="../css/styles.css">
     <script src="../js/reading-aids.js" defer></script>
 

--- a/start-here.html
+++ b/start-here.html
@@ -40,6 +40,10 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <!-- CSS -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
+         @import-ed from the stylesheet, which was render-blocking. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="css/styles.css">
 
     <!-- Structured Data - JSON-LD -->


### PR DESCRIPTION
You left this one to me, so here's the reasoning as well as the change — it's fully reversible in one PR if you dislike it.

## The pairing

| Role | Before | After |
|---|---|---|
| Reading | Inter | **Literata** (400/500/600 + italic) |
| Chrome | Space Grotesk | **Archivo** (500/600/700) |
| Technical | IBM Plex Mono | unchanged |

Inter and Space Grotesk are the two faces most associated with machine-generated layout, and using **both together** was one of the stronger signals that the design wasn't deliberately chosen. Inter is also a UI face — `lineage.html` sets 2,242 words in it.

Literata was drawn specifically for long-form reading on screen, which is what this site mostly is. IBM Plex Mono stays because it's genuinely right for haplogroup notation.

## The split now means something

Rather than serif-vs-sans as decoration: **what you read is Literata, what you navigate by is Archivo** — nav, buttons, TOC, table headers, kickers. The contrast tells you which is which.

Body text moves to 17px/1.7 with a 72ch measure on running prose. Tables, grids and diagrams keep their own widths.

## Two loading bugs found on the way

1. **The fonts were `@import`-ed** at the top of `styles.css` — which blocks rendering until the stylesheet is fetched *and* parsed, then starts a second request chain. Now a `<link>` in `<head>`, where the existing `preconnect` hints were already pointing but had nothing to accelerate.

2. **`Lexend` was never loaded.** `.region-map`, `.genetic-diagram` and `.phylogenetic-tree` labels all asked for it; no stylesheet ever fetched it, so those labels silently fell back to the browser default. Mapped to Archivo.

## Also

Moved the revision date out of the homepage hero, where it interrupted the headline. On a landing page it's a footnote, not a byline.

## Verified

Three families load with no silent fallbacks. Lighthouse mobile accessibility **100**, zero failures.

Supersedes `.cursorrules` typography section; consolidated in #59.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDiEHHEbbZtihboWBaUcr5