### PR TITLE
fix: inline font-family declarations still asked for unloaded families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Social previews now use a real 1200x630 `og-card.jpg`. `og:image` had been pointing at a 2340x1334 PNG while declaring 1200x630, so previews were mis-sized; it stays JPEG because crawler support for WebP is still uneven
 
 ### Fixed
+- Five inline `font-family` declarations still asked for Space Grotesk, Inter or Lexend after the type change, none of which are loaded any more, so those elements silently fell back to a browser default
 - Cumulative Layout Shift on `lineage.html` dropped from 0.32 to 0.05. The table of contents is injected by JavaScript after parse, and below the rail breakpoint it lands in normal flow — an expanded nine-item list shoved the article down the page. It now starts collapsed there, and the diagram container reserves its height
 - `.toc-card.is-collapsed .toc-list` set `display: flex`, so collapsing the table of contents did not actually collapse it
 - Paternal and maternal lineages are now distinguishable in the diagrams and charts. Series colours follow a luminance-ordered warm ramp (3.27:1 in greyscale, up from 2.26:1) and carry a non-colour identifier: the maternal branch and node are dashed, the second line series has a dash pattern and its own point marker

--- a/genetics.html
+++ b/genetics.html
@@ -183,7 +183,7 @@
             <div style="display: grid; gap: 2rem; margin: 3rem 0;">
                 <div style="background: linear-gradient(to bottom right, rgba(212, 166, 41, 0.03), rgba(228, 194, 88, 0.06)); border: 1px solid rgba(212, 166, 41, 0.15); border-radius: 4px; padding: 2rem; position: relative; overflow: hidden; display: grid; grid-template-columns: 140px 1fr; gap: 2rem; align-items: start;">
                     <div style="position: absolute; top: 0; right: 0; width: 100px; height: 100px; background: linear-gradient(135deg, rgba(212, 166, 41, 0.08), transparent); border-radius: 0 0 0 100%;"></div>
-                    <div style="font-family: 'Space Grotesk', sans-serif; font-size: 1.125rem; font-weight: 700; color: var(--accent-text); border-right: 2px solid rgba(212, 166, 41, 0.2); padding-right: 2rem; line-height: 1.3;">1990-2003</div>
+                    <div style="font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif; font-size: 1.125rem; font-weight: 700; color: var(--accent-text); border-right: 2px solid rgba(212, 166, 41, 0.2); padding-right: 2rem; line-height: 1.3;">1990-2003</div>
                     <div>
                         <h3 style="font-size: 1.25rem; font-weight: 700; color: var(--text-primary); margin-bottom: 1rem;">The Human Genome Project Era</h3>
                         <p style="margin: 0.5rem 0; color: var(--text-secondary); line-height: 1.6;"><strong>Time:</strong> 13 years of international collaboration</p>
@@ -195,7 +195,7 @@
                 
                 <div style="background: linear-gradient(to bottom right, rgba(228, 194, 88, 0.03), rgba(226, 163, 107, 0.06)); border: 1px solid rgba(228, 194, 88, 0.15); border-radius: 4px; padding: 2rem; position: relative; overflow: hidden; display: grid; grid-template-columns: 140px 1fr; gap: 2rem; align-items: start;">
                     <div style="position: absolute; top: 0; right: 0; width: 100px; height: 100px; background: linear-gradient(135deg, rgba(228, 194, 88, 0.08), transparent); border-radius: 0 0 0 100%;"></div>
-                    <div style="font-family: 'Space Grotesk', sans-serif; font-size: 1.125rem; font-weight: 700; color: var(--accent-text); border-right: 2px solid rgba(228, 194, 88, 0.2); padding-right: 2rem; line-height: 1.3;">2004-2010</div>
+                    <div style="font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif; font-size: 1.125rem; font-weight: 700; color: var(--accent-text); border-right: 2px solid rgba(228, 194, 88, 0.2); padding-right: 2rem; line-height: 1.3;">2004-2010</div>
                     <div>
                         <h3 style="font-size: 1.25rem; font-weight: 700; color: var(--text-primary); margin-bottom: 1rem;">Next-Generation Sequencing</h3>
                         <p style="margin: 0.5rem 0; color: var(--text-secondary); line-height: 1.6;"><strong>Time:</strong> Months to weeks</p>
@@ -207,7 +207,7 @@
                 
                 <div style="background: linear-gradient(to bottom right, rgba(226, 163, 107, 0.03), rgba(205, 127, 50, 0.06)); border: 1px solid rgba(226, 163, 107, 0.15); border-radius: 4px; padding: 2rem; position: relative; overflow: hidden; display: grid; grid-template-columns: 140px 1fr; gap: 2rem; align-items: start;">
                     <div style="position: absolute; top: 0; right: 0; width: 100px; height: 100px; background: linear-gradient(135deg, rgba(226, 163, 107, 0.08), transparent); border-radius: 0 0 0 100%;"></div>
-                    <div style="font-family: 'Space Grotesk', sans-serif; font-size: 1.125rem; font-weight: 700; color: var(--accent-text); border-right: 2px solid rgba(226, 163, 107, 0.2); padding-right: 2rem; line-height: 1.3;">2011-2024</div>
+                    <div style="font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif; font-size: 1.125rem; font-weight: 700; color: var(--accent-text); border-right: 2px solid rgba(226, 163, 107, 0.2); padding-right: 2rem; line-height: 1.3;">2011-2024</div>
                     <div>
                         <h3 style="font-size: 1.25rem; font-weight: 700; color: var(--text-primary); margin-bottom: 1rem;">Consumer Revolution</h3>
                         <p style="margin: 0.5rem 0; color: var(--text-secondary); line-height: 1.6;"><strong>Time:</strong> Days to hours</p>
@@ -219,7 +219,7 @@
                 
                 <div style="background: linear-gradient(to bottom right, rgba(205, 127, 50, 0.03), rgba(212, 166, 41, 0.06)); border: 1px solid rgba(205, 127, 50, 0.15); border-radius: 4px; padding: 2rem; position: relative; overflow: hidden; display: grid; grid-template-columns: 140px 1fr; gap: 2rem; align-items: start;">
                     <div style="position: absolute; top: 0; right: 0; width: 100px; height: 100px; background: linear-gradient(135deg, rgba(205, 127, 50, 0.08), transparent); border-radius: 0 0 0 100%;"></div>
-                    <div style="font-family: 'Space Grotesk', sans-serif; font-size: 1.125rem; font-weight: 700; color: var(--text-primary); border-right: 2px solid rgba(205, 127, 50, 0.2); padding-right: 2rem; line-height: 1.3;">2021-Present</div>
+                    <div style="font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif; font-size: 1.125rem; font-weight: 700; color: var(--text-primary); border-right: 2px solid rgba(205, 127, 50, 0.2); padding-right: 2rem; line-height: 1.3;">2021-Present</div>
                     <div>
                         <h3 style="font-size: 1.25rem; font-weight: 700; color: var(--text-primary); margin-bottom: 1rem;">Real-Time Genomics</h3>
                         <p style="margin: 0.5rem 0; color: var(--text-secondary); line-height: 1.6;"><strong>Time:</strong> Minutes to hours</p>

--- a/lineage.html
+++ b/lineage.html
@@ -190,7 +190,7 @@
                 <h3 style="text-align: center; color: var(--text-primary); margin-bottom: 1.5rem; font-size: 1.1rem; font-weight: 600;">Phylogenetic Heritage Overview</h3>
                 
                 <div class="mermaid" style="display: flex; justify-content: center;">
-%%{init: {'theme':'base', 'themeVariables': { 'fontSize':'14px', 'fontFamily':'Inter'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'fontSize':'14px', 'fontFamily':'Literata'}}}%%
 flowchart LR
     A[("Common<br/>Ancestor")]
     B["<b>Y-DNA: E-PF2546</b><br/>Paternal · African<br/><i>Indigenous North African,<br/>autochthonous to Amazigh</i>"]


### PR DESCRIPTION
Caught in the live post-deploy sweep.

The type change in #56 rewrote `css/styles.css` but **could not reach `font-family` declarations inside inline `style` attributes** — four in `genetics.html` asking for `'Space Grotesk'`, one in `lineage.html` asking for `'Inter'`. Neither family is loaded any more, so those elements silently fell back to whatever the browser picked.

This is the **fourth instance of the same bug class** in this run:

1. `Lexend` in the stylesheet (`.region-map`, `.genetic-diagram`, `.phylogenetic-tree`)
2. `Lexend` in three Chart.js label configs
3. `Space Grotesk` / `Inter` in inline styles — this PR

`DESIGN.md` already carries the rule that every `font-family` must resolve to a loaded family with a real fallback stack. This brings the markup in line with it.

## Verified

No reference to Space Grotesk, Inter or Lexend remains anywhere in HTML, CSS or JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDiEHHEbbZtihboWBaUcr5