### PR TITLE
content: publish three stranded research articles, align all twelve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Three research summaries that had been sitting unpublished on the old fork since PR #8 and never reached the live site: Canary Islands Amazigh history (Santana et al. 2025), demographic modelling of Amazigh–Arab divergence (2024), and Islamic-period Ibiza gene flow (2026). The research index now lists 12 papers
 - A Limitations page stating what two haplogroups can and cannot show — two ancestral lines out of more than a thousand, why a haplogroup is not an ethnicity, and how wide the TMRCA ranges actually are (#49)
 - A visible "Last updated" date on every page, kept in step with JSON-LD `dateModified` and `sitemap.xml` (#48)
 - A sourcing note on the culture page stating plainly that its material comes from community and family knowledge rather than peer-reviewed literature (#47)
 
 ### Changed
+- The nine existing research articles were brought onto the current design: constant brand bar, page title as the `<h1>` in `<main>`, sequential heading levels, WebP imagery, corrected social images and the shared footer. The brand-bar work in #50 had only reached the top-level pages, because the articles' markup is minified and the regex missed them
 - Removed emoji from 77 headings across the site; #24 had only covered part of one page (#61)
 - One consistent footer on every page — three variants existed, and most research articles had no secondary navigation at all
 - The site name is now a constant brand bar on every page; the page title moved into `<main>` as the `<h1>`, so the brand no longer disappears as you navigate (#50)
@@ -27,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Social previews now use a real 1200x630 `og-card.jpg`. `og:image` had been pointing at a 2340x1334 PNG while declaring 1200x630, so previews were mis-sized; it stays JPEG because crawler support for WebP is still uneven
 
 ### Fixed
+- Two contrast failures in article-only components: the hero caption used Tailwind's `#6B7280` at 4.39:1 and the paper date `#8B7355` at 4.22:1. Both now use `--text-secondary`
 - Five inline `font-family` declarations still asked for Space Grotesk, Inter or Lexend after the type change, none of which are loaded any more, so those elements silently fell back to a browser default
 - Cumulative Layout Shift on `lineage.html` dropped from 0.32 to 0.05. The table of contents is injected by JavaScript after parse, and below the rail breakpoint it lands in normal flow — an expanded nine-item list shoved the article down the page. It now starts collapsed there, and the diagram container reserves its height
 - `.toc-card.is-collapsed .toc-list` set `display: flex`, so collapsing the table of contents did not actually collapse it

--- a/css/styles.css
+++ b/css/styles.css
@@ -912,7 +912,7 @@ img {
     align-items: center;
     gap: 0.5rem;
     font-size: 0.875rem;
-    color: #6B7280;
+    color: var(--text-secondary);
 }
 
 .breadcrumb li:not(:last-child)::after {
@@ -3999,7 +3999,7 @@ select:focus {
 
 .discovery-date {
     font-size: 0.8rem;
-    color: #8B7355;
+    color: var(--text-secondary);
     font-family: 'IBM Plex Mono', monospace;
 }
 
@@ -4114,7 +4114,7 @@ select:focus {
 .start-path-time {
     font-family: 'IBM Plex Mono', monospace;
     font-size: 0.78rem;
-    color: #8B7355;
+    color: var(--text-secondary);
 }
 
 .start-path-title {
@@ -4420,7 +4420,7 @@ main#main-content.has-reading-aids {
     padding: 0.75rem 1rem 0.9rem;
     font-size: 0.82rem;
     line-height: 1.5;
-    color: #6B7280;
+    color: var(--text-secondary);
     background: rgba(212, 166, 41, 0.05);
     border-top: 1px solid rgba(212, 166, 41, 0.2);
 }
@@ -4507,7 +4507,7 @@ main#main-content.has-reading-aids {
 
 .paper-date {
     font-size: 0.8rem;
-    color: #8B7355;
+    color: var(--text-secondary);
     font-family: 'IBM Plex Mono', monospace;
     margin-left: auto;
 }
@@ -4751,7 +4751,7 @@ main#main-content.has-reading-aids {
 
 .home-hero-meta-copy {
     font-size: 0.75rem;
-    color: #6B7280;
+    color: var(--text-secondary);
 }
 
 @media (max-width: 900px) {
@@ -5439,4 +5439,23 @@ th {
 
 @media (min-width: 1024px) {
     .mermaid { min-height: 380px; }
+}
+
+/* Research article sections. The paper title is the page <h1>, so these are
+   <h2>/<h3> for the document outline — but they keep the smaller sizes they
+   had, because visual weight and heading rank are different things. */
+.card h2.article-head {
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    margin: 2rem 0 1rem;
+    color: var(--primary-navy);
+}
+
+.card h3.article-subhead {
+    font-family: 'Archivo', 'Helvetica Neue', Arial, sans-serif;
+    font-size: 1.15rem;
+    font-weight: 600;
+    margin: 1.5rem 0 0.75rem;
+    color: var(--text-primary);
 }

--- a/research.html
+++ b/research.html
@@ -107,7 +107,7 @@
         <p class="page-updated">Last updated: 6 September 2026</p>
         <div class="editorial-meta" aria-label="Editorial metadata">
             <span class="meta-pill">Last updated: July 9, 2026</span>
-            <span class="meta-pill">9 article summaries</span>
+            <span class="meta-pill">12 article summaries</span>
             <span class="meta-pill">Focus: North African population genetics</span>
         </div>
 
@@ -360,6 +360,66 @@
             <a href="limitations.html">Limitations</a>
             <a href="maps-sites.html">Maps &amp; Sites</a>
             <a href="contact.html">Contact</a>
+
+            <a href="research/mediterranean-islamic-dna-ibiza-2026.html" class="discovery-card discovery-card-plain discovery-card-copper" data-category="ancient-dna" data-date="2026-02" data-citations="12">
+                            <img
+                                src="img/map-maghreb.webp"
+                                alt="Western Mediterranean context map connecting North Africa to the Balearic Islands"
+                                class="discovery-cover-image"
+                                loading="lazy"
+                                decoding="async"
+                            >
+                            <div class="discovery-card-head">
+                                <span class="discovery-tag discovery-tag-copper">Ancient DNA</span>
+                                <span class="discovery-date">Feb 2026</span>
+                            </div>
+                            <h3 class="discovery-title">Islamic Period Ibiza Burials Reveal North African Gene Flow</h3>
+                            <p class="discovery-summary">Rodríguez-Varela et al. analyze medieval genomes (950–1150 CE), confirming two-pulse North African demographic influx during the Umayyad and Almoravid eras.</p>
+                            <div class="discovery-cta">
+                                <span class="discovery-cta-label text-copper">Read Summary</span>
+                                <span class="text-copper">&rarr;</span>
+                            </div>
+                        </a>
+
+            <a href="research/canary-islands-amazigh-history-2025.html" class="discovery-card discovery-card-plain discovery-card-sienna" data-category="ancient-dna" data-date="2025-03" data-citations="15">
+                            <img
+                                src="img/map-maghreb.webp"
+                                alt="Map showing Canary Islands geographic proximity to southwestern Morocco"
+                                class="discovery-cover-image"
+                                loading="lazy"
+                                decoding="async"
+                            >
+                            <div class="discovery-card-head">
+                                <span class="discovery-tag discovery-tag-sienna">Ancient DNA</span>
+                                <span class="discovery-date">Mar 2025</span>
+                            </div>
+                            <h3 class="discovery-title">Demographic History of Canary Islands During the Pre-Colonial Amazigh Period</h3>
+                            <p class="discovery-summary">Santana et al. integrate palaeogenomics and climate modeling, demonstrating direct genetic continuity between ancient Guanches and mainland Berber populations.</p>
+                            <div class="discovery-cta">
+                                <span class="discovery-cta-label text-sienna">Read Summary</span>
+                                <span class="text-sienna">&rarr;</span>
+                            </div>
+                        </a>
+
+            <a href="research/demographic-modelling-amazigh-arab-2024.html" class="discovery-card discovery-card-plain discovery-card-clay" data-category="ancient-dna" data-date="2024-08" data-citations="35">
+                            <img
+                                src="img/E-PF2546-map.webp"
+                                alt="North African demographic modeling map"
+                                class="discovery-cover-image"
+                                loading="lazy"
+                                decoding="async"
+                            >
+                            <div class="discovery-card-head">
+                                <span class="discovery-tag discovery-tag-clay">Genomics</span>
+                                <span class="discovery-date">Aug 2024</span>
+                            </div>
+                            <h3 class="discovery-title">Demographic History Points to Epipaleolithic Roots for Amazigh Populations</h3>
+                            <p class="discovery-summary">Serradell et al. (Genome Biology) construct deep-learning demographic models proving separate Epipaleolithic origins for Amazigh groups vs post-Islamic Arabization gene flow.</p>
+                            <div class="discovery-cta">
+                                <span class="discovery-cta-label text-clay">Read Summary</span>
+                                <span class="text-clay">&rarr;</span>
+                            </div>
+                        </a>
         </nav>
     </footer>
 

--- a/research/amazigh-genomic-heterogeneity-2024.html
+++ b/research/amazigh-genomic-heterogeneity-2024.html
@@ -80,10 +80,12 @@
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
 
-    <header role="banner">
+        <header role="banner">
         <div class="header-content">
-            <h1>North African Amazigh Heritage</h1>
-            <p>A Journey Through Time: Tracing Genetic, Historical, and Cultural Roots in the Souss-Massa</p>
+            <a class="site-brand" href="../index.html">
+                <span class="site-brand-mark" aria-hidden="true"></span>
+                <span class="site-brand-name">North African Amazigh Heritage</span>
+            </a>
         </div>
     </header>
     <nav class="main-nav">
@@ -142,7 +144,7 @@
                 <span class="paper-badge paper-badge-journal">Scientific Reports</span>
                 <span class="paper-date">May 2024</span>
             </div>
-            <h2 class="paper-title">Understanding the Genomic Heterogeneity of North African Imazighen: From Broad to Microgeographical Perspectives</h2>
+            <h1 class="paper-title">Understanding the Genomic Heterogeneity of North African Imazighen: From Broad to Microgeographical Perspectives</h1>
             <p class="paper-citation">Vilà-Valls, L., Abdeli, A., Lucas-Sánchez, M., Bekada, A., Calafell, F., Benhassine, T., &amp; Comas, D. (2024). <em>Scientific Reports</em>, 14(1), 9979.</p>
             <div class="paper-actions">
                 <a href="https://doi.org/10.1038/s41598-024-60568-8" target="_blank" rel="noopener noreferrer" class="paper-doi-link paper-doi-sienna">View Full Paper (DOI) &rarr;</a>
@@ -152,14 +154,14 @@
 
         <!-- Summary -->
         <section class="card article-section">
-            <h3>Summary</h3>
+            <h2 class="article-head">Summary</h2>
             <p>This study from the Universitat Pompeu Fabra presents the most comprehensive genomic survey of North African Imazighen (Amazigh/Berber) populations published to date. The researchers assembled a dataset spanning multiple Amazigh-speaking groups from Morocco, Algeria, and the Saharan fringe, comparing broad regional patterns with fine-grained microgeographical structure within individual communities.</p>
             <p>Applying principal component analysis (PCA), ADMIXTURE clustering, runs-of-homozygosity (ROH) analysis, and identity-by-descent (IBD) comparisons, the team reconstructed a layered picture of Amazigh population history. The deepest layer of Amazigh ancestry links directly to the 15,100&ndash;13,900-year-old Epipalaeolithic Iberomaurusian foragers from Taforalt, Morocco, confirming the autochthonous and ancient character of the Imazighen gene pool.</p>
             <p>Above this Epipaleolithic foundation, the study identified at least two subsequent admixture waves with sub-Saharan African populations: one centred around the 12th century CE, likely associated with trans-Saharan trade networks and the slave trade, and a second wave around the 19th century CE. The proportions and geographic distribution of sub-Saharan ancestry differ markedly between Amazigh groups depending on their proximity to trans-Saharan routes. The study also found evidence for negative assortative mating as the dominant mating pattern, with endogamy restricted to small isolated sub-groups.</p>
         </section>
 
         <section class="card article-section">
-            <h3>Study Region</h3>
+            <h2 class="article-head">Study Region</h2>
             <div class="article-map-frame">
                 <iframe
                     src="https://www.google.com/maps?q=31.0,0.0&t=k&z=5&output=embed"
@@ -173,7 +175,7 @@
 
         <!-- Key Takeaways -->
         <section class="card article-section takeaways-sienna">
-            <h3>Key Takeaways</h3>
+            <h2 class="article-head">Key Takeaways</h2>
             <ul class="takeaways-list">
                 <li>Largest Amazigh genomic dataset compiled to date, covering multiple Moroccan and Algerian Imazighen communities at both regional and microgeographical scales</li>
                 <li>The deepest Amazigh ancestry layer traces back to Iberomaurusian foragers at Taforalt, Morocco (~15,100&ndash;13,900 years ago), confirming Epipaleolithic roots</li>
@@ -186,28 +188,28 @@
 
         <!-- Relevance to Our Lineage -->
         <section class="card article-section">
-            <h3>Relevance to Our Lineage</h3>
+            <h2 class="article-head">Relevance to Our Lineage</h2>
             <p>This study is directly relevant to interpreting the genetic context of the Chtouka lineage from the Souss-Massa. The confirmation that Moroccan Amazigh populations maintain a deep Epipalaeolithic ancestry layer, anchored to the Iberomaurusian horizon at Taforalt, places the Anti-Atlas Aït M&rsquo;Hend lineage within the broader autochthonous North African genetic continuum discussed on our <a href="../lineage.html" class="text-sienna">Lineage History</a> page.</p>
             <p>The identification of two historically datable trans-Saharan admixture waves is also significant for our <a href="../genetics.html" class="text-sienna">Genetics</a> analysis. Small proportions of sub-Saharan African ancestry detectable in modern Moroccan Amazigh genomes are now traceable to specific historical periods (12th and 19th centuries CE) rather than ancient or poorly defined processes&mdash;providing a calibrated timeline for interpreting admixture signals in personal genomic results from the Souss-Massa region.</p>
             <p>The finding of high microgeographical diversity within Amazigh groups also cautions against over-generalising &ldquo;North African Amazigh&rdquo; as a uniform genetic category. The Chtouka lineage of the Anti-Atlas belongs to a regional sub-population whose specific admixture profile may differ meaningfully from Amazigh groups in the Rif, Kabylie, or the Saharan fringe.</p>
         </section>
 
         <section class="card">
-            <h3>Related Reading</h3>
+            <h2 class="article-head">Related Reading</h2>
             <div class="related-grid">
                 <a href="north-africa-demographic-history-2024.html" class="related-link-card">
-                    <h4>North African Demographic History (2024)</h4>
+                    <h3 class="article-subhead">North African Demographic History (2024)</h3>
                     <p>AI-driven modelling shows Amazigh-Arab divergence over 20,000 years ago via a soft split scenario.</p>
                 </a>
                 <a href="north-african-mitogenomes-2025.html" class="related-link-card">
-                    <h4>North African Mitogenomes (2025)</h4>
+                    <h3 class="article-subhead">North African Mitogenomes (2025)</h3>
                     <p>Massive 733-genome mtDNA survey confirming H1 subclade distributions and female-mediated dispersals.</p>
                 </a>
             </div>
         </section>
 
         <section class="card updates-cta">
-            <h3>Follow Future Summaries</h3>
+            <h2 class="article-head">Follow Future Summaries</h2>
             <p>For occasional updates on newly published research pages, subscribe on the contact page.</p>
             <a href="../contact.html#updates-signup" class="btn">Subscribe to Updates</a>
         </section>

--- a/research/canary-islands-amazigh-history-2025.html
+++ b/research/canary-islands-amazigh-history-2025.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en" prefix="og: http://ogp.me/ns#">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <!-- SEO Meta Tags -->
+    <title>Canary Islands Amazigh History | Santana et al. 2025</title>
+    <meta name="description" content="Summary of Santana et al. 2025 (Scientific Reports): Demographic history and resilience of the Guanches (indigenous Canarian Amazighs) prior to European colonization.">
+    <meta name="keywords" content="Canary Islands ancient DNA 2025, Guanche genetics, indigenous Amazigh Canaries, Berber archaeology, Santana 2025">
+    <meta name="author" content="North African Amazigh Heritage Project">
+    <meta name="robots" content="index, follow, max-image-preview:large">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="North African Amazigh Heritage">
+    <meta property="og:title" content="Canary Islands Amazigh History — Santana et al. 2025">
+    <meta property="og:description" content="Demographic history and human resilience of the Guanches during the pre-colonial Amazigh period.">
+    <meta property="og:url" content="https://northafricanorigins.com/research/canary-islands-amazigh-history-2025.html">
+    <meta property="og:image" content="https://northafricanorigins.com/img/og-card.jpg">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Canary Islands Amazigh History — Santana et al. 2025">
+    <meta name="twitter:description" content="Genomic and environmental modeling of indigenous Guanche Amazigh populations.">
+    <meta name="twitter:image" content="https://northafricanorigins.com/img/og-card.jpg">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://northafricanorigins.com/research/canary-islands-amazigh-history-2025.html">
+
+    <!-- Favicon and Performance -->
+    <link rel="icon" type="image/png" href="../favicon-32x32.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="../favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="../favicon-16x16.png">
+    <link rel="manifest" href="../site.webmanifest">
+    <meta name="theme-color" content="#3E2723">
+
+    <!-- Preconnect for Performance -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
+    <!-- CSS -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="../css/styles.css">
+    <script src="../js/reading-aids.js" defer></script>
+
+    <!-- Structured Data - JSON-LD -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ScholarlyArticle",
+      "headline": "Climate, biogeography, and human resilience in the demographic history of the Canary Islands during the Amazigh period",
+      "description": "Summary of Santana et al. 2025: Demographic history of the pre-colonial Guanche Amazigh population",
+      "author": {
+        "@type": "Organization",
+        "name": "North African Amazigh Heritage Project"
+      },
+      "datePublished": "2025-03-01",
+      "about": {
+        "@type": "ScholarlyArticle",
+        "name": "Climate, biogeography, and human resilience in the demographic history of the Canary Islands during the Amazigh period",
+        "author": "Santana, J. et al.",
+        "datePublished": "2025",
+        "isPartOf": {
+          "@type": "Periodical",
+          "name": "Scientific Reports"
+        }
+      },
+      "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "https://northafricanorigins.com/research/canary-islands-amazigh-history-2025.html"
+      }
+    }
+    </script>
+</head>
+
+<body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+
+        <header role="banner">
+        <div class="header-content">
+            <a class="site-brand" href="../index.html">
+                <span class="site-brand-mark" aria-hidden="true"></span>
+                <span class="site-brand-name">North African Amazigh Heritage</span>
+            </a>
+        </div>
+    </header>
+    <nav class="main-nav">
+        <div class="nav-container">
+            <a href="../index.html">Home</a>
+            <a href="../lineage.html">Lineage History</a>
+            <a href="../genetics.html">Genetics</a>
+            <a href="../culture.html">Culture</a>
+            <a href="../research.html" class="active">Research</a>
+            <a href="../maps-sites.html">Maps &amp; Sites</a>
+            <a href="../glossary.html">Glossary</a>
+            <a href="../contact.html">Contact</a>
+        </div>
+    </nav>
+
+    <nav aria-label="Breadcrumb" class="breadcrumb">
+        <ol itemscope itemtype="https://schema.org/BreadcrumbList">
+            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                <a itemprop="item" href="../index.html"><span itemprop="name">Home</span></a>
+                <meta itemprop="position" content="1" />
+            </li>
+            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                <a itemprop="item" href="../research.html"><span itemprop="name">Research</span></a>
+                <meta itemprop="position" content="2" />
+            </li>
+            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                <span itemprop="name">Canary Islands Amazigh History</span>
+                <meta itemprop="position" content="3" />
+            </li>
+        </ol>
+    </nav>
+
+    <main id="main-content" class="container" role="main">
+        <div class="editorial-meta" aria-label="Article metadata">
+            <span class="meta-pill">Summary updated: July 2026</span>
+            <span class="meta-pill">Estimated read: 4 min</span>
+            <span class="meta-pill">Primary source: Scientific Reports (2025)</span>
+        </div>
+
+        <figure class="card article-hero-media">
+            <img
+                src="../img/map-maghreb.webp"
+                alt="Map showing the Canary Islands off the southwest coast of Morocco"
+                class="article-hero-image"
+                loading="eager"
+                decoding="async"
+            >
+            <figcaption class="article-hero-caption">Geographic proximity of the Canary Islands to the Souss-Massa and southwestern Moroccan Atlantic coast.</figcaption>
+        </figure>
+
+        <section class="card article-section paper-card-sienna">
+            <div class="paper-meta-row">
+                <span class="paper-badge paper-badge-sienna">Ancient DNA</span>
+                <span class="paper-badge paper-badge-journal">Scientific Reports</span>
+                <span class="paper-date">March 2025</span>
+            </div>
+            <h1 class="paper-title">Climate, Biogeography, and Human Resilience in the Demographic History of the Canary Islands During the Amazigh Period</h1>
+            <p class="paper-citation">Santana, J. et al. (2025). <em>Scientific Reports</em>, 15, 4302.</p>
+            <div class="paper-actions">
+                <a href="https://doi.org/10.1038/s41598-025-04302-y" target="_blank" rel="noopener noreferrer" class="paper-doi-link paper-doi-sienna">View Full Paper (DOI) &rarr;</a>
+            </div>
+        </section>
+
+        <section class="card article-section">
+            <h2 class="article-head">Summary</h2>
+            <p>The Canary Islands were populated around the 1st millennium BCE by indigenous North African Amazigh settlers (historically known as Guanches). In this 2025 multidisciplinary study, Santana and colleagues integrated palaeogenomics, palaeoclimate modeling, and archaeological data to reconstruct the demographic history of the archipelago during its pre-colonial Amazigh period.</p>
+            <p>The results demonstrate long-term genetic continuity with mainland Northwest African Berber populations (specifically harboring high frequencies of Y-DNA E-M81 and mtDNA U6b1a / H1). The study highlights how indigenous islanders adapted resilient agricultural and pastoral strategies to navigate severe medieval droughts and climatic shifts prior to 15th-century European conquest.</p>
+        </section>
+
+        <section class="card article-section takeaways-sienna">
+            <h2 class="article-head">Key Takeaways</h2>
+            <ul class="takeaways-list">
+                <li>Integrated palaeogenomics and palaeoclimate models for the indigenous pre-colonial Canarian Amazigh period.</li>
+                <li>Confirmed direct genetic continuity with mainland North African Berber populations (E-M81, U6b1a, H1).</li>
+                <li>Demonstrated long-term population resilience against severe medieval drought cycles.</li>
+                <li>Provides crucial insular context for the westernmost extension of Amazigh seafaring and settlement.</li>
+            </ul>
+        </section>
+
+        <section class="card article-section">
+            <h2 class="article-head">Relevance to Our Lineage</h2>
+            <p>Situated directly off the Atlantic coast of the Souss-Massa region, the Canary Islands represent the insular extension of southwestern Moroccan Amazigh heritage. The genetic alignment between ancient Guanches and mainland Berber populations underscores the shared deep-time origins of communities along the Souss Atlantic corridor.</p>
+        </section>
+
+        <section class="card">
+            <h2 class="article-head">Related Reading</h2>
+            <div class="related-grid">
+                <a href="amazigh-genomic-heterogeneity-2024.html" class="related-link-card">
+                    <h3 class="article-subhead">Amazigh Genomic Heterogeneity (2024)</h3>
+                    <p>Microgeographical genomic structure across mainland Amazigh populations.</p>
+                </a>
+                <a href="e-m183-recent-origin-2018.html" class="related-link-card">
+                    <h3 class="article-subhead">E-M183 Recent Origin (2018)</h3>
+                    <p>Expansion of Y-haplogroup E-M81 across North Africa and insular territories.</p>
+                </a>
+            </div>
+        </section>
+
+        <div class="article-nav">
+            <a href="../research.html" class="article-back-link text-sienna">&larr; Back to Research</a>
+            <div class="article-nav-actions">
+                <a href="../lineage.html" class="btn btn-outline btn-outline-copper btn-small">Lineage History</a>
+                <a href="../genetics.html" class="btn btn-outline btn-outline-ochre btn-small">Genetics</a>
+            </div>
+        </div>
+    </main>
+
+    <footer role="contentinfo">
+        <p>&copy; 2026 North African Amazigh Heritage Project | Preserving Chtouka heritage of the Souss-Massa</p>
+        <nav class="footer-nav" aria-label="Secondary navigation">
+            <a href="../start-here.html">Start Here</a>
+            <a href="../glossary.html">Glossary</a>
+            <a href="../limitations.html">Limitations</a>
+            <a href="../maps-sites.html">Maps &amp; Sites</a>
+            <a href="../contact.html">Contact</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/research/demographic-modelling-amazigh-arab-2024.html
+++ b/research/demographic-modelling-amazigh-arab-2024.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html>
+<html lang="en" prefix="og: http://ogp.me/ns#">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <!-- SEO Meta Tags -->
+    <title>Demographic History of North African Genomes | Serradell et al. 2024</title>
+    <meta name="description" content="Summary of Serradell et al. 2024 (Genome Biology): Whole-genome demographic modeling reveals distinct Epipaleolithic origins for Amazigh populations vs. Arabization gene flow.">
+    <meta name="keywords" content="North Africa demographic modeling 2024, Amazigh vs Arab genetics, Epipaleolithic North Africa, GP4PG, Serradell 2024, Genome Biology">
+    <meta name="author" content="North African Amazigh Heritage Project">
+    <meta name="robots" content="index, follow, max-image-preview:large">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="North African Amazigh Heritage">
+    <meta property="og:title" content="Demographic History of North African Genomes — Serradell et al. 2024">
+    <meta property="og:description" content="Whole-genome deep-learning modeling demonstrates distinct Epipaleolithic origins for Amazigh groups and recent Arabization gene flow.">
+    <meta property="og:url" content="https://northafricanorigins.com/research/demographic-modelling-amazigh-arab-2024.html">
+    <meta property="og:image" content="https://northafricanorigins.com/img/og-card.jpg">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Demographic History of North African Genomes — Serradell et al. 2024">
+    <meta name="twitter:description" content="Deep learning demographic models point to Epipaleolithic roots for Amazigh populations in North Africa.">
+    <meta name="twitter:image" content="https://northafricanorigins.com/img/og-card.jpg">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://northafricanorigins.com/research/demographic-modelling-amazigh-arab-2024.html">
+
+    <!-- Favicon and Performance -->
+    <link rel="icon" type="image/png" href="../favicon-32x32.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="../favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="../favicon-16x16.png">
+    <link rel="manifest" href="../site.webmanifest">
+    <meta name="theme-color" content="#3E2723">
+
+    <!-- Preconnect for Performance -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
+    <!-- CSS -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="../css/styles.css">
+    <script src="../js/reading-aids.js" defer></script>
+
+    <!-- Structured Data - JSON-LD -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ScholarlyArticle",
+      "headline": "Modelling the demographic history of human North African genomes points to a recent soft split divergence between populations",
+      "description": "Summary of Serradell et al. 2024: Whole-genome demographic modeling demonstrating Epipaleolithic origins for Amazigh populations",
+      "author": {
+        "@type": "Organization",
+        "name": "North African Amazigh Heritage Project"
+      },
+      "datePublished": "2024-08-20",
+      "about": {
+        "@type": "ScholarlyArticle",
+        "name": "Modelling the demographic history of human North African genomes points to a recent soft split divergence between populations",
+        "author": "Serradell, J. M. et al.",
+        "datePublished": "2024",
+        "isPartOf": {
+          "@type": "Periodical",
+          "name": "Genome Biology"
+        }
+      },
+      "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "https://northafricanorigins.com/research/demographic-modelling-amazigh-arab-2024.html"
+      }
+    }
+    </script>
+</head>
+
+<body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+
+        <header role="banner">
+        <div class="header-content">
+            <a class="site-brand" href="../index.html">
+                <span class="site-brand-mark" aria-hidden="true"></span>
+                <span class="site-brand-name">North African Amazigh Heritage</span>
+            </a>
+        </div>
+    </header>
+    <nav class="main-nav">
+        <div class="nav-container">
+            <a href="../index.html">Home</a>
+            <a href="../lineage.html">Lineage History</a>
+            <a href="../genetics.html">Genetics</a>
+            <a href="../culture.html">Culture</a>
+            <a href="../research.html" class="active">Research</a>
+            <a href="../maps-sites.html">Maps &amp; Sites</a>
+            <a href="../glossary.html">Glossary</a>
+            <a href="../contact.html">Contact</a>
+        </div>
+    </nav>
+
+    <nav aria-label="Breadcrumb" class="breadcrumb">
+        <ol itemscope itemtype="https://schema.org/BreadcrumbList">
+            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                <a itemprop="item" href="../index.html"><span itemprop="name">Home</span></a>
+                <meta itemprop="position" content="1" />
+            </li>
+            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                <a itemprop="item" href="../research.html"><span itemprop="name">Research</span></a>
+                <meta itemprop="position" content="2" />
+            </li>
+            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                <span itemprop="name">Demographic Modeling of North African Genomes</span>
+                <meta itemprop="position" content="3" />
+            </li>
+        </ol>
+    </nav>
+
+    <main id="main-content" class="container" role="main">
+        <div class="editorial-meta" aria-label="Article metadata">
+            <span class="meta-pill">Summary updated: July 2026</span>
+            <span class="meta-pill">Estimated read: 5 min</span>
+            <span class="meta-pill">Primary source: Genome Biology (2024)</span>
+        </div>
+
+        <figure class="card article-hero-media">
+            <img
+                src="../img/E-PF2546-map.webp"
+                alt="Map illustrating North African population structure and ancestral migrations"
+                class="article-hero-image"
+                loading="eager"
+                decoding="async"
+            >
+            <figcaption class="article-hero-caption">Demographic model context depicting deep autochthonous Berber lineages and Eurasian back-migrations into North Africa.</figcaption>
+        </figure>
+
+        <section class="card article-section paper-card-clay">
+            <div class="paper-meta-row">
+                <span class="paper-badge paper-badge-clay">Genomics</span>
+                <span class="paper-badge paper-badge-journal">Genome Biology</span>
+                <span class="paper-date">August 2024</span>
+            </div>
+            <h1 class="paper-title">Modelling the Demographic History of Human North African Genomes Points to a Recent Soft Split Divergence</h1>
+            <p class="paper-citation">Serradell, J. M., Lorenzo-Salazar, J. M., Flores, C., Lao, O., &amp; Comas, D. (2024). <em>Genome Biology</em>, 25, 226.</p>
+            <div class="paper-actions">
+                <a href="https://doi.org/10.1186/s13059-024-03341-4" target="_blank" rel="noopener noreferrer" class="paper-doi-link paper-doi-clay">View Full Paper (DOI) &rarr;</a>
+                <a href="https://pubmed.ncbi.nlm.nih.gov/39164801/" target="_blank" rel="noopener noreferrer" class="paper-doi-link paper-doi-clay">View PubMed Record &rarr;</a>
+            </div>
+        </section>
+
+        <section class="card article-section">
+            <h2 class="article-head">Summary</h2>
+            <p>North African human populations present a complex demographic scenario shaped by an autochthonous genetic core, local population substructure, and extensive gene flow from the Middle East, Europe, and Sub-Saharan Africa. In this 2024 landmark study published in <em>Genome Biology</em>, Serradell and colleagues analyzed 364 whole genomes (including high-coverage &gt;30X sequencing) to construct detailed demographic models comparing the two main ethnic and linguistic divisions in North Africa: Amazigh and Arab populations.</p>
+            <p>Using an Approximate Bayesian Computation framework paired with Deep Learning (ABC-DL) and an algorithmic method named Genetic Programming for Population Genetics (GP4PG), the authors evaluated competing demographic topologies. The best-supported model demonstrates that Amazigh groups trace their primary genetic origin back to Epipaleolithic times (over 10,000–15,000 years ago), maintaining deep continuity with ancient local hunter-gatherers. In contrast, the arrival of Middle Eastern components in Arabized groups corresponds to distinct, later gene-flow events during the historical Arabization period.</p>
+            <p>Crucially, the GP4PG model shows that population divergence across North Africa was driven by "soft splits"—gradual separation with continuous, decaying gene flow—rather than sudden demographic replacement pulses.</p>
+        </section>
+
+        <section class="card article-section takeaways-clay">
+            <h2 class="article-head">Key Takeaways</h2>
+            <ul class="takeaways-list">
+                <li>High-coverage whole-genome modeling (364 genomes) confirms distinct demographic trajectories for Amazigh and Arab populations.</li>
+                <li>Amazigh populations exhibit deep genetic roots extending directly to local Epipaleolithic populations (Taforalt-like hunter-gatherer continuity).</li>
+                <li>Arab populations reflect substantial gene flow associated with historical medieval Arabization.</li>
+                <li>North African population divergence is characterized by continuous "soft splits" with decaying gene flow rather than abrupt pulse replacements.</li>
+                <li>Re-affirms a ancient "back-to-Africa" migration hypothesis connecting prehistoric North Africans with Eurasian ancestral streams.</li>
+            </ul>
+        </section>
+
+        <section class="card article-section">
+            <h2 class="article-head">Relevance to Our Lineage</h2>
+            <p>This study provides authoritative genomic backing for the deep antiquity of Amazigh lineages in the Maghreb. By proving that Amazigh populations maintain an unbroken genetic core dating back to Epipaleolithic times, Serradell et al. confirm that local Y-DNA (such as E-M81 / E-PF2546) and mtDNA (such as H1) represent indigenous North African heritage preserved across millennia of historical transitions.</p>
+        </section>
+
+        <section class="card">
+            <h2 class="article-head">Related Reading</h2>
+            <div class="related-grid">
+                <a href="e-m183-recent-origin-2018.html" class="related-link-card">
+                    <h3 class="article-subhead">E-M183 Recent Origin (2018)</h3>
+                    <p>Phylogenetic analysis of haplogroup E-M81/E-M183 expansion in North Africa.</p>
+                </a>
+                <a href="green-sahara-ancient-dna-2025.html" class="related-link-card">
+                    <h3 class="article-subhead">Green Sahara Ancient DNA (2025)</h3>
+                    <p>Ancient DNA evidence for deep-time Saharan and Maghrebi ancestral lineages.</p>
+                </a>
+            </div>
+        </section>
+
+        <div class="article-nav">
+            <a href="../research.html" class="article-back-link text-clay">&larr; Back to Research</a>
+            <div class="article-nav-actions">
+                <a href="../lineage.html" class="btn btn-outline btn-outline-copper btn-small">Lineage History</a>
+                <a href="../genetics.html" class="btn btn-outline btn-outline-ochre btn-small">Genetics</a>
+            </div>
+        </div>
+    </main>
+
+    <footer role="contentinfo">
+        <p>&copy; 2026 North African Amazigh Heritage Project | Preserving Chtouka heritage of the Souss-Massa</p>
+        <nav class="footer-nav" aria-label="Secondary navigation">
+            <a href="../start-here.html">Start Here</a>
+            <a href="../glossary.html">Glossary</a>
+            <a href="../limitations.html">Limitations</a>
+            <a href="../maps-sites.html">Maps &amp; Sites</a>
+            <a href="../contact.html">Contact</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/research/e-m183-recent-origin-2018.html
+++ b/research/e-m183-recent-origin-2018.html
@@ -80,10 +80,12 @@
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
 
-    <header role="banner">
+        <header role="banner">
         <div class="header-content">
-            <h1>North African Amazigh Heritage</h1>
-            <p>A Journey Through Time: Tracing Genetic, Historical, and Cultural Roots in the Souss-Massa</p>
+            <a class="site-brand" href="../index.html">
+                <span class="site-brand-mark" aria-hidden="true"></span>
+                <span class="site-brand-name">North African Amazigh Heritage</span>
+            </a>
         </div>
     </header>
     <nav class="main-nav">
@@ -142,7 +144,7 @@
                 <span class="paper-badge paper-badge-journal">Scientific Reports</span>
                 <span class="paper-date">November 2017</span>
             </div>
-            <h2 class="paper-title">Whole Y-Chromosome Sequences Reveal an Extremely Recent Origin of E-M183</h2>
+            <h1 class="paper-title">Whole Y-Chromosome Sequences Reveal an Extremely Recent Origin of E-M183</h1>
             <p class="paper-citation">Solé-Morata, N. et al. (2017). <em>Scientific Reports</em>, 7, 15941.</p>
             <div class="paper-actions">
                 <a href="https://doi.org/10.1038/s41598-017-16271-y" target="_blank" rel="noopener noreferrer" class="paper-doi-link paper-doi-sienna">View Full Paper (DOI) &rarr;</a>
@@ -152,14 +154,14 @@
 
         <!-- Summary -->
         <section class="card article-section">
-            <h3>Summary</h3>
+            <h2 class="article-head">Summary</h2>
             <p>This study used whole Y-chromosome sequencing to reconstruct the phylogeny and dating of haplogroup E-M81 (also known as E-M183), the most common Y-DNA lineage among Amazigh (Berber) populations. Previous estimates based on microsatellite data had placed the origin of E-M81 much earlier, but this high-resolution approach dramatically revised the timeline.</p>
             <p>The researchers sequenced complete Y-chromosomes from men carrying E-M81 across North Africa and determined that the time to the most recent common ancestor (TMRCA) of this lineage is only approximately 2,000&ndash;3,000 years before present. This is far more recent than earlier estimates of 5,000&ndash;10,000 years.</p>
             <p>The phylogenetic tree revealed a striking star-like topology, indicating a rapid demographic expansion from a small founding population. This pattern is consistent with a population bottleneck followed by explosive growth, possibly linked to the adoption of camel pastoralism, trans-Saharan trade networks, or the consolidation of Amazigh confederations during the late first millennium BCE.</p>
         </section>
 
         <section class="card article-section">
-            <h3>Study Region</h3>
+            <h2 class="article-head">Study Region</h2>
             <div class="article-map-frame">
                 <iframe
                     src="https://www.google.com/maps?q=30.5,-6.5&t=k&z=4&output=embed"
@@ -173,7 +175,7 @@
 
         <!-- Key Takeaways -->
         <section class="card article-section takeaways-sienna">
-            <h3>Key Takeaways</h3>
+            <h2 class="article-head">Key Takeaways</h2>
             <ul class="takeaways-list">
                 <li>E-M81/E-M183 TMRCA dated to ~2,000&ndash;3,000 years before present via whole Y-chromosome sequencing</li>
                 <li>This is significantly more recent than prior microsatellite-based estimates of 5,000&ndash;10,000 years</li>
@@ -185,28 +187,28 @@
 
         <!-- Relevance to Our Lineage -->
         <section class="card article-section">
-            <h3>Relevance to Our Lineage</h3>
+            <h2 class="article-head">Relevance to Our Lineage</h2>
             <p>This study is foundational to the paternal lineage analysis presented throughout this site. E-PF2546, the specific Y-DNA haplogroup carried by the Chtouka lineage, is a subclade within the E-M81/E-M183 branch. The dating of E-M81's expansion to ~2,000&ndash;3,000 years ago (~300 BCE to 1000 BCE) directly informs the timeline discussed on our <a href="../lineage.html" class="text-sienna">Lineage History</a> page.</p>
             <p>The star-like expansion pattern aligns with the historical narrative of Amazigh confederation formation in the Souss-Massa region. The rapid population growth from a small founding group is consistent with the establishment and expansion of tribal confederations like the Chtouka, where patrilineal descent structures would amplify specific Y-DNA lineages.</p>
             <p>The ~300 BCE date for E-PF2546 referenced on this site is derived from the branching structure established by this paper, placing the Chtouka lineage's diversification within the broader E-M81 expansion during a period of significant political and economic change across the Maghreb.</p>
         </section>
 
         <section class="card">
-            <h3>Related Reading</h3>
+            <h2 class="article-head">Related Reading</h2>
             <div class="related-grid">
                 <a href="green-sahara-ancient-dna-2025.html" class="related-link-card">
-                    <h4>Green Sahara Ancient DNA (2025)</h4>
+                    <h3 class="article-subhead">Green Sahara Ancient DNA (2025)</h3>
                     <p>Deep-time context from ancient Saharan genomes and North African population structure.</p>
                 </a>
                 <a href="neolithic-iberia-morocco-2023.html" class="related-link-card">
-                    <h4>Neolithic Iberia-Morocco (2023)</h4>
+                    <h3 class="article-subhead">Neolithic Iberia-Morocco (2023)</h3>
                     <p>Ancient migration pathways relevant to maternal lineages in Northwest Africa.</p>
                 </a>
             </div>
         </section>
 
         <section class="card updates-cta">
-            <h3>Follow Future Summaries</h3>
+            <h2 class="article-head">Follow Future Summaries</h2>
             <p>For occasional updates on newly published research pages, subscribe on the contact page.</p>
             <a href="../contact.html#updates-signup" class="btn">Subscribe to Updates</a>
         </section>

--- a/research/eastern-maghreb-neolithic-continuity-2025.html
+++ b/research/eastern-maghreb-neolithic-continuity-2025.html
@@ -81,10 +81,12 @@
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
 
-    <header role="banner">
+        <header role="banner">
         <div class="header-content">
-            <h1>North African Amazigh Heritage</h1>
-            <p>A Journey Through Time: Tracing Genetic, Historical, and Cultural Roots in the Souss-Massa</p>
+            <a class="site-brand" href="../index.html">
+                <span class="site-brand-mark" aria-hidden="true"></span>
+                <span class="site-brand-name">North African Amazigh Heritage</span>
+            </a>
         </div>
     </header>
     <nav class="main-nav">
@@ -141,7 +143,7 @@
                 <span class="paper-badge paper-badge-journal">Nature</span>
                 <span class="paper-date">March 2025</span>
             </div>
-            <h2 class="paper-title">High Continuity of Forager Ancestry in the Neolithic Period of the Eastern Maghreb</h2>
+            <h1 class="paper-title">High Continuity of Forager Ancestry in the Neolithic Period of the Eastern Maghreb</h1>
             <p class="paper-citation">Lipson, M. et al. (2025). <em>Nature</em>, 641, 925-931.</p>
             <div class="paper-actions">
                 <a href="https://doi.org/10.1038/s41586-025-08699-4" target="_blank" rel="noopener noreferrer" class="paper-doi-link paper-doi-clay">View Full Paper (DOI) &rarr;</a>
@@ -150,14 +152,14 @@
         </section>
 
         <section class="card article-section">
-            <h3>Summary</h3>
+            <h2 class="article-head">Summary</h2>
             <p>This study generated genome-wide ancient DNA data for nine individuals from Algeria and Tunisia, spanning the Later Stone Age to the Neolithic. It fills a major gap in North African archaeogenetics, which previously relied heavily on data from western Maghreb sites.</p>
             <p>The earliest eastern Maghreb individuals aligned closely with pre-Neolithic western Maghreb populations, showing that an indigenous "Maghrebi" ancestry profile persisted across a wide geography and long timeframe (roughly 15,000-7,600 years BP).</p>
             <p>The Neolithic transition in the eastern Maghreb was characterized by continuity with limited external input: one ~8,000-year-old Tunisian individual had European hunter-gatherer-related ancestry (likely early Holocene movement across the Strait of Sicily), while later Neolithic individuals carried mostly local ancestry with smaller European farmer and Levantine contributions by ~7,000-6,800 years BP.</p>
         </section>
 
         <section class="card article-section takeaways-clay">
-            <h3>Key Takeaways</h3>
+            <h2 class="article-head">Key Takeaways</h2>
             <ul class="takeaways-list">
                 <li>Ancient DNA from Algeria and Tunisia confirms long-term continuity of indigenous Maghrebi ancestry through the Neolithic transition</li>
                 <li>The eastern Maghreb retained more local forager ancestry than many other Mediterranean Neolithic regions</li>
@@ -168,20 +170,20 @@
         </section>
 
         <section class="card article-section">
-            <h3>Relevance to Indigenous North African History</h3>
+            <h2 class="article-head">Relevance to Indigenous North African History</h2>
             <p>For Amazigh history, this paper strengthens the case that the Maghreb was not simply repopulated by incoming Neolithic groups. Instead, indigenous communities remained central while selectively integrating external ancestry through long-distance contacts.</p>
             <p>This continuity model is directly relevant to this site's lineage framework, where deep local North African paternal continuity coexists with layered maternal and autosomal signals from later prehistoric and historical connections.</p>
         </section>
 
         <section class="card">
-            <h3>Related Reading</h3>
+            <h2 class="article-head">Related Reading</h2>
             <div class="related-grid">
                 <a href="neolithic-iberia-morocco-2023.html" class="related-link-card">
-                    <h4>Neolithic Iberia-Morocco (2023)</h4>
+                    <h3 class="article-subhead">Neolithic Iberia-Morocco (2023)</h3>
                     <p>Ancient DNA evidence for migration routes linking Iberia and Neolithic Morocco.</p>
                 </a>
                 <a href="green-sahara-ancient-dna-2025.html" class="related-link-card">
-                    <h4>Green Sahara Ancient DNA (2025)</h4>
+                    <h3 class="article-subhead">Green Sahara Ancient DNA (2025)</h3>
                     <p>Ancient DNA from Libya adding deep-time context for Holocene North Africa.</p>
                 </a>
             </div>

--- a/research/green-sahara-ancient-dna-2025.html
+++ b/research/green-sahara-ancient-dna-2025.html
@@ -17,13 +17,13 @@
     <meta property="og:title" content="Green Sahara Ancient DNA — Salem et al. 2025">
     <meta property="og:description" content="Ancient DNA from the Green Sahara reveals ancestral North African lineage with basal haplogroup N.">
     <meta property="og:url" content="https://northafricanorigins.com/research/green-sahara-ancient-dna-2025.html">
-    <meta property="og:image" content="https://northafricanorigins.com/img/research/green-sahara-takarkori-rock-shelter-nature-2025.webp">
+    <meta property="og:image" content="https://northafricanorigins.com/img/og-card.jpg">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Green Sahara Ancient DNA — Salem et al. 2025">
     <meta name="twitter:description" content="Ancient DNA from the Green Sahara reveals ancestral North African lineage.">
-    <meta name="twitter:image" content="https://northafricanorigins.com/img/research/green-sahara-takarkori-rock-shelter-nature-2025.webp">
+    <meta name="twitter:image" content="https://northafricanorigins.com/img/og-card.jpg">
 
     <!-- Canonical URL -->
     <link rel="canonical" href="https://northafricanorigins.com/research/green-sahara-ancient-dna-2025.html">
@@ -80,10 +80,12 @@
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
 
-    <header role="banner">
+        <header role="banner">
         <div class="header-content">
-            <h1>North African Amazigh Heritage</h1>
-            <p>A Journey Through Time: Tracing Genetic, Historical, and Cultural Roots in the Souss-Massa</p>
+            <a class="site-brand" href="../index.html">
+                <span class="site-brand-mark" aria-hidden="true"></span>
+                <span class="site-brand-name">North African Amazigh Heritage</span>
+            </a>
         </div>
     </header>
     <nav class="main-nav">
@@ -142,7 +144,7 @@
                 <span class="paper-badge paper-badge-journal">Nature</span>
                 <span class="paper-date">January 2025</span>
             </div>
-            <h2 class="paper-title">Ancient DNA from the Green Sahara Reveals Ancestral North African Lineage</h2>
+            <h1 class="paper-title">Ancient DNA from the Green Sahara Reveals Ancestral North African Lineage</h1>
             <p class="paper-citation">Salem, T. et al. (2025). <em>Nature</em>, 641, 144&ndash;150.</p>
             <div class="paper-actions">
                 <a href="https://doi.org/10.1038/s41586-025-08793-7" target="_blank" rel="noopener noreferrer" class="paper-doi-link paper-doi-copper">View Full Paper (DOI) &rarr;</a>
@@ -152,14 +154,14 @@
 
         <!-- Summary -->
         <section class="card article-section">
-            <h3>Summary</h3>
+            <h2 class="article-head">Summary</h2>
             <p>This landmark study recovered ancient DNA from human remains in the Takarkori rock shelter in southwestern Libya, dating to approximately 7,000 years ago during the "Green Sahara" period (African Humid Period). The Sahara was then a lush, habitable landscape supporting pastoralist communities.</p>
             <p>The researchers successfully sequenced the genome of these ancient Saharan inhabitants and discovered they carried a previously unknown basal lineage of mitochondrial haplogroup N. This lineage diverged early from other Eurasian branches and had not been detected in any modern or ancient population previously studied.</p>
             <p>The findings indicate that the Green Sahara harbored genetically distinct populations that contributed to the ancestry of later North African groups, but in complex ways that cannot be explained by simple models of north-south migration. The genetic isolation of these Saharan groups during the humid period suggests regional population structuring across North Africa during the Holocene.</p>
         </section>
 
         <section class="card article-section">
-            <h3>Takarkori Site Location</h3>
+            <h2 class="article-head">Takarkori Site Location</h2>
             <div class="article-map-frame">
                 <iframe
                     src="https://www.google.com/maps?q=24.538,10.521&t=k&z=12&output=embed"
@@ -173,7 +175,7 @@
 
         <!-- Key Takeaways -->
         <section class="card article-section takeaways-copper">
-            <h3>Key Takeaways</h3>
+            <h2 class="article-head">Key Takeaways</h2>
             <ul class="takeaways-list">
                 <li>First successful ancient DNA recovery from the Sahara, dating to ~7,000 years before present during the African Humid Period</li>
                 <li>Identified a novel basal branch of mitochondrial haplogroup N not found in any living population</li>
@@ -185,28 +187,28 @@
 
         <!-- Relevance to Our Lineage -->
         <section class="card article-section">
-            <h3>Relevance to Our Lineage</h3>
+            <h2 class="article-head">Relevance to Our Lineage</h2>
             <p>While this study focuses on populations from a different time and place than the Chtouka lineage, it provides critical context for understanding the deep ancestry of all North African groups, including the Amazigh (Berber) populations of the Souss-Massa.</p>
             <p>The discovery of a basal haplogroup N lineage in the Sahara demonstrates that North Africa's genetic landscape was shaped by multiple distinct population layers over millennia. This complexity supports the dual-origin model discussed on our <a href="../lineage.html" class="text-copper">Lineage History</a> page, where indigenous North African paternal lineages (E-PF2546) coexist with maternal lineages (H1-T16189C!) that arrived via different migration routes.</p>
             <p>The Green Sahara period represents one of several major demographic events that shaped the genetic diversity observed in modern Amazigh populations, preceding the later expansions that gave rise to the E-M81/E-PF2546 lineage.</p>
         </section>
 
         <section class="card">
-            <h3>Related Reading</h3>
+            <h2 class="article-head">Related Reading</h2>
             <div class="related-grid">
                 <a href="north-african-mitogenomes-2025.html" class="related-link-card">
-                    <h4>North African Mitogenomes (2025)</h4>
+                    <h3 class="article-subhead">North African Mitogenomes (2025)</h3>
                     <p>Large-scale mtDNA survey that refines maternal lineage structure across North Africa.</p>
                 </a>
                 <a href="neolithic-iberia-morocco-2023.html" class="related-link-card">
-                    <h4>Neolithic Iberia-Morocco (2023)</h4>
+                    <h3 class="article-subhead">Neolithic Iberia-Morocco (2023)</h3>
                     <p>Ancient DNA evidence for migration routes linking Iberia and Neolithic Morocco.</p>
                 </a>
             </div>
         </section>
 
         <section class="card updates-cta">
-            <h3>Follow Future Summaries</h3>
+            <h2 class="article-head">Follow Future Summaries</h2>
             <p>For occasional updates on newly published research pages, subscribe on the contact page.</p>
             <a href="../contact.html#updates-signup" class="btn">Subscribe to Updates</a>
         </section>

--- a/research/mediterranean-islamic-dna-ibiza-2026.html
+++ b/research/mediterranean-islamic-dna-ibiza-2026.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en" prefix="og: http://ogp.me/ns#">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <!-- SEO Meta Tags -->
+    <title>Islamic Period Ibiza Ancient DNA | Rodríguez-Varela et al. 2026</title>
+    <meta name="description" content="Summary of Rodríguez-Varela et al. 2026 (Nature Communications): Ancient genomes from medieval Ibiza (950-1150 CE) reveal North African gene flow during the Umayyad and Almoravid periods.">
+    <meta name="keywords" content="Ibiza ancient DNA 2026, Islamic period Balearics, North African medieval gene flow, Almoravid genetics, Rodríguez-Varela 2026">
+    <meta name="author" content="North African Amazigh Heritage Project">
+    <meta name="robots" content="index, follow, max-image-preview:large">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="North African Amazigh Heritage">
+    <meta property="og:title" content="Islamic Period Ibiza Ancient DNA — Rodríguez-Varela et al. 2026">
+    <meta property="og:description" content="Ancient DNA from medieval Ibiza confirms two-pulse North African demographic expansion into the western Mediterranean.">
+    <meta property="og:url" content="https://northafricanorigins.com/research/mediterranean-islamic-dna-ibiza-2026.html">
+    <meta property="og:image" content="https://northafricanorigins.com/img/og-card.jpg">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Islamic Period Ibiza Ancient DNA — Rodríguez-Varela et al. 2026">
+    <meta name="twitter:description" content="Genomes from 950–1150 CE reveal North African ancestry pulses in the Balearic Islands.">
+    <meta name="twitter:image" content="https://northafricanorigins.com/img/og-card.jpg">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://northafricanorigins.com/research/mediterranean-islamic-dna-ibiza-2026.html">
+
+    <!-- Favicon and Performance -->
+    <link rel="icon" type="image/png" href="../favicon-32x32.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="../favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="../favicon-16x16.png">
+    <link rel="manifest" href="../site.webmanifest">
+    <meta name="theme-color" content="#3E2723">
+
+    <!-- Preconnect for Performance -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
+    <!-- CSS -->
+    <!-- Typography: Literata for long-form reading, Archivo for headings and
+         chrome, IBM Plex Mono for haplogroup notation. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="../css/styles.css">
+    <script src="../js/reading-aids.js" defer></script>
+
+    <!-- Structured Data - JSON-LD -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ScholarlyArticle",
+      "headline": "Analysis of medieval burials from Ibiza reveals genetic and pathogenic diversity during the Islamic period",
+      "description": "Summary of Rodríguez-Varela et al. 2026: Ancient DNA from Islamic period Ibiza showing North African admixture",
+      "author": {
+        "@type": "Organization",
+        "name": "North African Amazigh Heritage Project"
+      },
+      "datePublished": "2026-02-10",
+      "about": {
+        "@type": "ScholarlyArticle",
+        "name": "Analysis of medieval burials from Ibiza reveals genetic and pathogenic diversity during the Islamic period",
+        "author": "Rodríguez-Varela, R. et al.",
+        "datePublished": "2026",
+        "isPartOf": {
+          "@type": "Periodical",
+          "name": "Nature Communications"
+        }
+      },
+      "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "https://northafricanorigins.com/research/mediterranean-islamic-dna-ibiza-2026.html"
+      }
+    }
+    </script>
+</head>
+
+<body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+
+        <header role="banner">
+        <div class="header-content">
+            <a class="site-brand" href="../index.html">
+                <span class="site-brand-mark" aria-hidden="true"></span>
+                <span class="site-brand-name">North African Amazigh Heritage</span>
+            </a>
+        </div>
+    </header>
+    <nav class="main-nav">
+        <div class="nav-container">
+            <a href="../index.html">Home</a>
+            <a href="../lineage.html">Lineage History</a>
+            <a href="../genetics.html">Genetics</a>
+            <a href="../culture.html">Culture</a>
+            <a href="../research.html" class="active">Research</a>
+            <a href="../maps-sites.html">Maps &amp; Sites</a>
+            <a href="../glossary.html">Glossary</a>
+            <a href="../contact.html">Contact</a>
+        </div>
+    </nav>
+
+    <nav aria-label="Breadcrumb" class="breadcrumb">
+        <ol itemscope itemtype="https://schema.org/BreadcrumbList">
+            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                <a itemprop="item" href="../index.html"><span itemprop="name">Home</span></a>
+                <meta itemprop="position" content="1" />
+            </li>
+            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                <a itemprop="item" href="../research.html"><span itemprop="name">Research</span></a>
+                <meta itemprop="position" content="2" />
+            </li>
+            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                <span itemprop="name">Medieval Ibiza Ancient DNA</span>
+                <meta itemprop="position" content="3" />
+            </li>
+        </ol>
+    </nav>
+
+    <main id="main-content" class="container" role="main">
+        <div class="editorial-meta" aria-label="Article metadata">
+            <span class="meta-pill">Summary updated: July 2026</span>
+            <span class="meta-pill">Estimated read: 4 min</span>
+            <span class="meta-pill">Primary source: Nature Communications (2026)</span>
+        </div>
+
+        <figure class="card article-hero-media">
+            <img
+                src="../img/map-maghreb.webp"
+                alt="Map showing Mediterranean trade and conquest routes connecting North Africa to the Balearics"
+                class="article-hero-image"
+                loading="eager"
+                decoding="async"
+            >
+            <figcaption class="article-hero-caption">Western Mediterranean context connecting North Africa, Al-Andalus, and the Balearic Islands during the Islamic period.</figcaption>
+        </figure>
+
+        <section class="card article-section paper-card-copper">
+            <div class="paper-meta-row">
+                <span class="paper-badge paper-badge-copper">Ancient DNA</span>
+                <span class="paper-badge paper-badge-journal">Nature Communications</span>
+                <span class="paper-date">February 2026</span>
+            </div>
+            <h1 class="paper-title">Analysis of Medieval Burials from Ibiza Reveals Genetic and Pathogenic Diversity During the Islamic Period</h1>
+            <p class="paper-citation">Rodríguez-Varela, R. et al. (2026). <em>Nature Communications</em>, 17, 70615.</p>
+            <div class="paper-actions">
+                <a href="https://doi.org/10.1038/s41467-026-70615-9" target="_blank" rel="noopener noreferrer" class="paper-doi-link paper-doi-copper">View Full Paper (DOI) &rarr;</a>
+            </div>
+        </section>
+
+        <section class="card article-section">
+            <h2 class="article-head">Summary</h2>
+            <p>Ibiza was conquered in 902 CE under the Umayyad Emirate of Córdoba and remained under Islamic rule until 1235 CE. In this 2026 study published in <em>Nature Communications</em>, Rodríguez-Varela and colleagues analyzed genome-wide ancient DNA and metagenomics from 13 individuals buried in an Islamic cemetery in Ibiza, dated securely to 950–1150 CE.</p>
+            <p>Genome-wide analyses revealed substantial genetic diversity, with ancestral components tracing to local Western European, North African, and Sub-Saharan African populations. The authors estimated that North African gene flow occurred 2 to 7 generations prior to these individuals, providing empirical genetic validation for historical Arabic sources documenting a **two-pulse demographic model**: an initial 10th-century conquest settlement followed by a major 12th-century North African population influx associated with the Almoravid movement.</p>
+            <p>Sub-Saharan ancestry components in specific individuals were traced to Senegambia and southern Chad, directly evidencing medieval trans-Saharan connectivity across Islamic trade networks.</p>
+        </section>
+
+        <section class="card article-section takeaways-copper">
+            <h2 class="article-head">Key Takeaways</h2>
+            <ul class="takeaways-list">
+                <li>Sequenced 13 ancient genomes from medieval Islamic Ibiza (950–1150 CE).</li>
+                <li>Empirically confirmed North African gene flow occurring 2–7 generations prior to burial.</li>
+                <li>Validated historical records of a **two-pulse demographic model**: 10th-century Umayyad conquest + 12th-century Almoravid movement.</li>
+                <li>Identified direct genetic links to Sub-Saharan regions (Senegambia, Chad), documenting medieval trans-Saharan networks.</li>
+                <li>Demonstrates the extensive trans-Mediterranean movement of Maghrebi populations during the medieval Islamic era.</li>
+            </ul>
+        </section>
+
+        <section class="card article-section">
+            <h2 class="article-head">Relevance to Our Lineage</h2>
+            <p>This study directly documents the outward expansion of North African populations into the western Mediterranean during the Almoravid era (11th–12th centuries CE)—a period centered around southwestern Morocco and the Souss region. It illustrates how Maghrebi lineages actively participated in shaping the demographic and cultural landscape of Al-Andalus and the Mediterranean islands.</p>
+        </section>
+
+        <section class="card">
+            <h2 class="article-head">Related Reading</h2>
+            <div class="related-grid">
+                <a href="punic-genetic-diversity-2025.html" class="related-link-card">
+                    <h3 class="article-subhead">Punic Genetic Diversity (2025)</h3>
+                    <p>Ancient DNA showing indigenous North African ancestry in Punic Mediterranean sites.</p>
+                </a>
+                <a href="amazigh-genomic-heterogeneity-2024.html" class="related-link-card">
+                    <h3 class="article-subhead">Amazigh Genomic Heterogeneity (2024)</h3>
+                    <p>Genomic evidence for 12th-century Almoravid regional admixture waves.</p>
+                </a>
+            </div>
+        </section>
+
+        <div class="article-nav">
+            <a href="../research.html" class="article-back-link text-copper">&larr; Back to Research</a>
+            <div class="article-nav-actions">
+                <a href="../lineage.html" class="btn btn-outline btn-outline-copper btn-small">Lineage History</a>
+                <a href="../genetics.html" class="btn btn-outline btn-outline-ochre btn-small">Genetics</a>
+            </div>
+        </div>
+    </main>
+
+    <footer role="contentinfo">
+        <p>&copy; 2026 North African Amazigh Heritage Project | Preserving Chtouka heritage of the Souss-Massa</p>
+        <nav class="footer-nav" aria-label="Secondary navigation">
+            <a href="../start-here.html">Start Here</a>
+            <a href="../glossary.html">Glossary</a>
+            <a href="../limitations.html">Limitations</a>
+            <a href="../maps-sites.html">Maps &amp; Sites</a>
+            <a href="../contact.html">Contact</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/research/neolithic-iberia-morocco-2023.html
+++ b/research/neolithic-iberia-morocco-2023.html
@@ -80,10 +80,12 @@
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
 
-    <header role="banner">
+        <header role="banner">
         <div class="header-content">
-            <h1>North African Amazigh Heritage</h1>
-            <p>A Journey Through Time: Tracing Genetic, Historical, and Cultural Roots in the Souss-Massa</p>
+            <a class="site-brand" href="../index.html">
+                <span class="site-brand-mark" aria-hidden="true"></span>
+                <span class="site-brand-name">North African Amazigh Heritage</span>
+            </a>
         </div>
     </header>
     <nav class="main-nav">
@@ -141,7 +143,7 @@
                 <span class="paper-badge paper-badge-journal">Nature</span>
                 <span class="paper-date">June 2023</span>
             </div>
-            <h2 class="paper-title">Northwest African Neolithic Initiated by Migrants from Iberia and Levant</h2>
+            <h1 class="paper-title">Northwest African Neolithic Initiated by Migrants from Iberia and Levant</h1>
             <p class="paper-citation">Villalba-Mouco, V. et al. (2023). <em>Nature</em>, 618, 550&ndash;556.</p>
             <div class="paper-actions">
                 <a href="https://doi.org/10.1038/s41586-023-06166-6" target="_blank" rel="noopener noreferrer" class="paper-doi-link paper-doi-clay">View Full Paper (DOI) &rarr;</a>
@@ -150,14 +152,14 @@
         </section>
 
         <section class="card article-section">
-            <h3>Summary</h3>
+            <h2 class="article-head">Summary</h2>
             <p>This groundbreaking study sequenced ancient DNA from Neolithic-era human remains found at multiple sites in Morocco, providing the first direct genetic evidence for how farming and pastoralism arrived in Northwest Africa. The transition from hunter-gatherer to agricultural societies in this region had long been debated.</p>
             <p>The ancient Moroccan genomes revealed a mixture of two ancestral components: one related to Neolithic European (specifically Iberian) farmers, and another related to Levantine Neolithic populations. This dual ancestry indicates that the Neolithic revolution in Northwest Africa was driven by actual migration of people, not just the diffusion of ideas and technologies.</p>
             <p>The European Neolithic component confirms trans-Gibraltar contact during the Neolithic period (~7,500&ndash;5,000 years ago), with genetic evidence of migration across the Strait of Gibraltar. The Levantine component suggests a parallel eastern route of migration, possibly through Egypt or along the Mediterranean coast.</p>
         </section>
 
         <section class="card article-section">
-            <h3>Study Region</h3>
+            <h2 class="article-head">Study Region</h2>
             <div class="article-map-frame">
                 <iframe
                     src="https://www.google.com/maps?q=35.95,-5.53&t=k&z=7&output=embed"
@@ -170,7 +172,7 @@
         </section>
 
         <section class="card article-section takeaways-clay">
-            <h3>Key Takeaways</h3>
+            <h2 class="article-head">Key Takeaways</h2>
             <ul class="takeaways-list">
                 <li>First ancient DNA from Neolithic Morocco, directly dating the arrival of farming-associated lineages</li>
                 <li>Dual ancestry identified: Iberian Neolithic farmers + Levantine Neolithic populations</li>
@@ -181,21 +183,21 @@
         </section>
 
         <section class="card article-section">
-            <h3>Relevance to Our Lineage</h3>
+            <h2 class="article-head">Relevance to Our Lineage</h2>
             <p>This study provides the strongest direct evidence for the mechanism by which the H1 maternal lineage arrived in North Africa. The H1-T16189C! haplogroup discussed on our <a href="../lineage.html" class="text-clay">Lineage History</a> page originated in the Franco-Cantabrian refuge of southwestern Europe, and the Iberian Neolithic migration pathway documented in this paper represents the most likely route of arrival.</p>
             <p>The confirmation of trans-Gibraltar migration during the Neolithic period directly supports the timeline and route model presented on this site. The H1 lineage, dating to approximately 11,400 years before present, would have been carried by these migrating populations as they crossed from Iberia into Morocco.</p>
             <p>Importantly, the finding that indigenous Maghrebi ancestry persisted alongside incoming lineages mirrors the dual-origin pattern observed in the Chtouka lineage: the indigenous E-PF2546 paternal lineage coexisting with the European-origin H1 maternal lineage within the same population.</p>
         </section>
 
         <section class="card">
-            <h3>Related Reading</h3>
+            <h2 class="article-head">Related Reading</h2>
             <div class="related-grid">
                 <a href="north-african-mitogenomes-2025.html" class="related-link-card">
-                    <h4>North African Mitogenomes (2025)</h4>
+                    <h3 class="article-subhead">North African Mitogenomes (2025)</h3>
                     <p>Large-scale mtDNA structure and female-mediated dispersals across the Maghreb.</p>
                 </a>
                 <a href="green-sahara-ancient-dna-2025.html" class="related-link-card">
-                    <h4>Green Sahara Ancient DNA (2025)</h4>
+                    <h3 class="article-subhead">Green Sahara Ancient DNA (2025)</h3>
                     <p>Earlier Saharan population structure during the African Humid Period.</p>
                 </a>
             </div>

--- a/research/north-africa-demographic-history-2024.html
+++ b/research/north-africa-demographic-history-2024.html
@@ -80,10 +80,12 @@
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
 
-    <header role="banner">
+        <header role="banner">
         <div class="header-content">
-            <h1>North African Amazigh Heritage</h1>
-            <p>A Journey Through Time: Tracing Genetic, Historical, and Cultural Roots in the Souss-Massa</p>
+            <a class="site-brand" href="../index.html">
+                <span class="site-brand-mark" aria-hidden="true"></span>
+                <span class="site-brand-name">North African Amazigh Heritage</span>
+            </a>
         </div>
     </header>
     <nav class="main-nav">
@@ -142,7 +144,7 @@
                 <span class="paper-badge paper-badge-journal">Genome Biology</span>
                 <span class="paper-date">July 2024</span>
             </div>
-            <h2 class="paper-title">Modelling the Demographic History of Human North African Genomes Points to a Recent Soft Split Divergence Between Populations</h2>
+            <h1 class="paper-title">Modelling the Demographic History of Human North African Genomes Points to a Recent Soft Split Divergence Between Populations</h1>
             <p class="paper-citation">Serradell, J. M. et al. (2024). <em>Genome Biology</em>, 25, 201.</p>
             <div class="paper-actions">
                 <a href="https://doi.org/10.1186/s13059-024-03341-4" target="_blank" rel="noopener noreferrer" class="paper-doi-link paper-doi-clay">View Full Paper (DOI) &rarr;</a>
@@ -152,14 +154,14 @@
 
         <!-- Summary -->
         <section class="card article-section">
-            <h3>Summary</h3>
+            <h2 class="article-head">Summary</h2>
             <p>This landmark population-genetics study from the Universitat Pompeu Fabra (Barcelona) employed cutting-edge artificial intelligence to reconstruct the detailed demographic history of North African genomes. The team analyzed 364 complete whole-genome sequences from Amazigh (Imazighen/Berber) and Arab populations across Morocco, Algeria, Tunisia, Libya, and Egypt.</p>
             <p>Using two complementary AI-driven methods&mdash;Approximate Bayesian Computation with Deep Learning (ABC-DL) and a novel Genetic Programming for Population Genetics (GP4PG) algorithm&mdash;the researchers built and tested competing demographic models to determine how and when distinct North African population lineages formed. The GP4PG model provided a more robust and finely resolved fit to the data than previous approaches.</p>
             <p>The central finding is that the genetic separation between Amazigh and Arab populations in North Africa is ancient, rooted in the Epipaleolithic period more than 20,000 years ago. This deep divergence does not reflect a simple, sudden split; instead, the model supports a &ldquo;soft split&rdquo; scenario of continuously decaying gene flow after an initial population divergence&mdash;rather than discrete admixture pulses. The study also confirms a back-to-Africa population movement as the origin of North African Amazigh ancestry, consistent with archaeological skeletal remains in Morocco dated to approximately 22,000 years ago.</p>
         </section>
 
         <section class="card article-section">
-            <h3>Study Region</h3>
+            <h2 class="article-head">Study Region</h2>
             <div class="article-map-frame">
                 <iframe
                     src="https://www.google.com/maps?q=28.5,2.0&t=k&z=4&output=embed"
@@ -173,7 +175,7 @@
 
         <!-- Key Takeaways -->
         <section class="card article-section takeaways-clay">
-            <h3>Key Takeaways</h3>
+            <h2 class="article-head">Key Takeaways</h2>
             <ul class="takeaways-list">
                 <li>Amazigh (Imazighen) and Arab populations in North Africa diverged over 20,000 years ago, during the Epipaleolithic&mdash;long before the Arab Islamic expansions of the 7th century CE</li>
                 <li>A &ldquo;soft split&rdquo; model best describes North African population divergence: gradual, continuously decaying gene flow rather than discrete admixture pulses</li>
@@ -186,28 +188,28 @@
 
         <!-- Relevance to Our Lineage -->
         <section class="card article-section">
-            <h3>Relevance to Our Lineage</h3>
+            <h2 class="article-head">Relevance to Our Lineage</h2>
             <p>This study provides the most rigorous genomic framework yet for situating the deep Amazigh (Berber) roots of the Aït M&rsquo;Hend lineage. The confirmation that Imazighen ancestry in North Africa is autochthonous and Epipaleolithic in origin directly supports the narrative on our <a href="../lineage.html" class="text-clay">Lineage History</a> page: the E-PF2546 Y-DNA haplogroup belongs to a paternal tradition that has persisted in North Africa for tens of thousands of years.</p>
             <p>The back-to-Africa origin model aligns with the deep-time context for haplogroup E, whose ancestral branches emerged outside Africa and returned via the Sinai corridor. The soft-split divergence model also reframes how we interpret the genetic diversity seen within Amazigh populations today: rather than sudden migration shocks, long-term low-level contact with surrounding populations has gradually modulated the Amazigh genome without erasing its core autochthonous signature.</p>
             <p>The finding that Arab genetic input into North Africa is predominantly post-7th century CE is particularly significant, as it underscores the antiquity of the Amazigh lineages documented throughout this project and validates the genetic distinctiveness of populations like the Chtouka confederation of the Souss-Massa.</p>
         </section>
 
         <section class="card">
-            <h3>Related Reading</h3>
+            <h2 class="article-head">Related Reading</h2>
             <div class="related-grid">
                 <a href="amazigh-genomic-heterogeneity-2024.html" class="related-link-card">
-                    <h4>Amazigh Genomic Heterogeneity (2024)</h4>
+                    <h3 class="article-subhead">Amazigh Genomic Heterogeneity (2024)</h3>
                     <p>Microgeographical diversity within North African Imazighen populations and historical admixture waves.</p>
                 </a>
                 <a href="green-sahara-ancient-dna-2025.html" class="related-link-card">
-                    <h4>Green Sahara Ancient DNA (2025)</h4>
+                    <h3 class="article-subhead">Green Sahara Ancient DNA (2025)</h3>
                     <p>Deep-time context from ~7,000-year-old Saharan genomes revealing ancestral North African lineages.</p>
                 </a>
             </div>
         </section>
 
         <section class="card updates-cta">
-            <h3>Follow Future Summaries</h3>
+            <h2 class="article-head">Follow Future Summaries</h2>
             <p>For occasional updates on newly published research pages, subscribe on the contact page.</p>
             <a href="../contact.html#updates-signup" class="btn">Subscribe to Updates</a>
         </section>

--- a/research/north-africa-maternal-diversity-2026.html
+++ b/research/north-africa-maternal-diversity-2026.html
@@ -81,10 +81,12 @@
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
 
-    <header role="banner">
+        <header role="banner">
         <div class="header-content">
-            <h1>North African Amazigh Heritage</h1>
-            <p>A Journey Through Time: Tracing Genetic, Historical, and Cultural Roots in the Souss-Massa</p>
+            <a class="site-brand" href="../index.html">
+                <span class="site-brand-mark" aria-hidden="true"></span>
+                <span class="site-brand-name">North African Amazigh Heritage</span>
+            </a>
         </div>
     </header>
     <nav class="main-nav">
@@ -141,7 +143,7 @@
                 <span class="paper-badge paper-badge-journal">Mammalian Genome</span>
                 <span class="paper-date">March 2026</span>
             </div>
-            <h2 class="paper-title">The North African Maternal Genetic Diversity Enriched by Historical Migrations</h2>
+            <h1 class="paper-title">The North African Maternal Genetic Diversity Enriched by Historical Migrations</h1>
             <p class="paper-citation">Boumajdi, N. et al. (2026). <em>Mammalian Genome</em>.</p>
             <div class="paper-actions">
                 <a href="https://doi.org/10.1007/s00335-026-10209-4" target="_blank" rel="noopener noreferrer" class="paper-doi-link paper-doi-ochre">View Full Paper (DOI) &rarr;</a>
@@ -150,14 +152,14 @@
         </section>
 
         <section class="card article-section">
-            <h3>Summary</h3>
+            <h2 class="article-head">Summary</h2>
             <p>This 2026 study compiled 869 complete mitochondrial genomes from six North African populations to examine maternal diversity and population structure, with special emphasis on Morocco. The dataset is among the largest recent complete-mitogenome syntheses focused on North Africa.</p>
             <p>The authors report high haplotype diversity and low genetic differentiation across populations (FST approximately 0.001-0.014), supporting a genetically cohesive Maghreb core. Across the full dataset, 56 maternal haplogroups were identified, with U6, H, and L as dominant components.</p>
             <p>Demographic modeling suggests distinct trajectories among key lineages in Morocco: expansion in L, decline in U6, and expansion in H. The paper also integrates previously published Y-STR data, noting that E-M81 remains predominant in Moroccan, Algerian, and Tunisian populations.</p>
         </section>
 
         <section class="card article-section takeaways-ochre">
-            <h3>Key Takeaways</h3>
+            <h2 class="article-head">Key Takeaways</h2>
             <ul class="takeaways-list">
                 <li>869 complete mitogenomes from six North African populations provide high-resolution maternal lineage context</li>
                 <li>Low between-population differentiation (FST approximately 0.001-0.014) supports a cohesive Maghreb genetic core</li>
@@ -168,20 +170,20 @@
         </section>
 
         <section class="card article-section">
-            <h3>Relevance to Our Lineage</h3>
+            <h2 class="article-head">Relevance to Our Lineage</h2>
             <p>For this site's dual-lineage framework, the study reinforces two central points: strong maternal diversity within a connected Maghreb population structure, and continued predominance of E-M81 on the paternal side. That alignment supports the broader Amazigh (Berber) continuity model presented in our lineage narrative.</p>
             <p>The reported H expansion trend in Morocco is also consistent with the importance of H-derived maternal branches in western North Africa, while the U6 and L patterns emphasize that North African history includes both deep local roots and repeated historical gene flow.</p>
         </section>
 
         <section class="card">
-            <h3>Related Reading</h3>
+            <h2 class="article-head">Related Reading</h2>
             <div class="related-grid">
                 <a href="north-african-mitogenomes-2025.html" class="related-link-card">
-                    <h4>North African Mitogenomes (2025)</h4>
+                    <h3 class="article-subhead">North African Mitogenomes (2025)</h3>
                     <p>Large mtDNA survey establishing maternal subclade distributions and dispersal patterns.</p>
                 </a>
                 <a href="green-sahara-ancient-dna-2025.html" class="related-link-card">
-                    <h4>Green Sahara Ancient DNA (2025)</h4>
+                    <h3 class="article-subhead">Green Sahara Ancient DNA (2025)</h3>
                     <p>Ancient DNA evidence for deep-time North African ancestry from Holocene Libya.</p>
                 </a>
             </div>

--- a/research/north-african-mitogenomes-2025.html
+++ b/research/north-african-mitogenomes-2025.html
@@ -80,10 +80,12 @@
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
 
-    <header role="banner">
+        <header role="banner">
         <div class="header-content">
-            <h1>North African Amazigh Heritage</h1>
-            <p>A Journey Through Time: Tracing Genetic, Historical, and Cultural Roots in the Souss-Massa</p>
+            <a class="site-brand" href="../index.html">
+                <span class="site-brand-mark" aria-hidden="true"></span>
+                <span class="site-brand-name">North African Amazigh Heritage</span>
+            </a>
         </div>
     </header>
     <nav class="main-nav">
@@ -141,7 +143,7 @@
                 <span class="paper-badge paper-badge-journal">Scientific Reports</span>
                 <span class="paper-date">January 2025</span>
             </div>
-            <h2 class="paper-title">The Origin of Modern North Africans as Depicted by a Massive Survey of Mitogenomes</h2>
+            <h1 class="paper-title">The Origin of Modern North Africans as Depicted by a Massive Survey of Mitogenomes</h1>
             <p class="paper-citation">Colombo, G. et al. (2025). <em>Scientific Reports</em>.</p>
             <div class="paper-actions">
                 <a href="https://doi.org/10.1038/s41598-025-12209-x" target="_blank" rel="noopener noreferrer" class="paper-doi-link paper-doi-ochre">View Full Paper (DOI) &rarr;</a>
@@ -150,14 +152,14 @@
         </section>
 
         <section class="card article-section">
-            <h3>Summary</h3>
+            <h2 class="article-head">Summary</h2>
             <p>This study represents the largest mitogenome survey of North African populations to date, analyzing 733 modern complete mitochondrial genomes alongside 43 ancient mitogenomes from across the region. The researchers reconstructed detailed phylogenetic trees for the major haplogroups found in North Africa.</p>
             <p>The study confirmed and refined the distribution of haplogroup H1 subclades (H1v, H1w, H1x) across North Africa, showing distinct frequency patterns between western and eastern populations. These H1 subclades are considered markers of prehistoric European-to-North African migration, most likely arriving during the late Pleistocene or early Holocene.</p>
             <p>Critically, the analysis demonstrated that female-mediated dispersals played a significant role in shaping North African genetic diversity, with multiple waves of maternal lineage movement detectable in the mitogenome data. The study also identified several previously uncharacterized sub-branches within established North African haplogroups.</p>
         </section>
 
         <section class="card article-section">
-            <h3>Study Region</h3>
+            <h2 class="article-head">Study Region</h2>
             <div class="article-map-frame">
                 <iframe
                     src="https://www.google.com/maps?q=28.5,10.0&t=k&z=4&output=embed"
@@ -170,7 +172,7 @@
         </section>
 
         <section class="card article-section takeaways-ochre">
-            <h3>Key Takeaways</h3>
+            <h2 class="article-head">Key Takeaways</h2>
             <ul class="takeaways-list">
                 <li>Largest North African mitogenome study: 733 modern + 43 ancient complete mitochondrial sequences</li>
                 <li>Confirmed H1v, H1w, and H1x subclade distributions, with higher frequencies in western North Africa (Morocco, Algeria)</li>
@@ -181,21 +183,21 @@
         </section>
 
         <section class="card article-section">
-            <h3>Relevance to Our Lineage</h3>
+            <h2 class="article-head">Relevance to Our Lineage</h2>
             <p>This study is directly relevant to the maternal H1-T16189C! lineage discussed throughout this site. The confirmation of H1 subclade distributions in western North Africa, with particular concentration in Morocco, aligns precisely with the patterns described on our <a href="../lineage.html" class="text-ochre">Lineage History</a> page.</p>
             <p>The finding that H1 subclades arrived via female-mediated dispersals supports the migration model presented in our analysis: H1 lineages likely traveled from the Franco-Cantabrian refuge through Iberia and across the Strait of Gibraltar into North Africa during the late Pleistocene or Neolithic period.</p>
             <p>The study's scale provides statistical confidence in the H1 frequency patterns observed in the Souss-Massa and broader Moroccan Amazigh (Berber) populations, strengthening the evidence base for the dual paternal-maternal lineage model central to this project.</p>
         </section>
 
         <section class="card">
-            <h3>Related Reading</h3>
+            <h2 class="article-head">Related Reading</h2>
             <div class="related-grid">
                 <a href="green-sahara-ancient-dna-2025.html" class="related-link-card">
-                    <h4>Green Sahara Ancient DNA (2025)</h4>
+                    <h3 class="article-subhead">Green Sahara Ancient DNA (2025)</h3>
                     <p>Deep-time context for North African population structure before later historical expansions.</p>
                 </a>
                 <a href="neolithic-iberia-morocco-2023.html" class="related-link-card">
-                    <h4>Neolithic Iberia-Morocco (2023)</h4>
+                    <h3 class="article-subhead">Neolithic Iberia-Morocco (2023)</h3>
                     <p>Ancient migration pathways linking Iberia and Northwest Africa.</p>
                 </a>
             </div>

--- a/research/punic-genetic-diversity-2025.html
+++ b/research/punic-genetic-diversity-2025.html
@@ -58,7 +58,14 @@
 </head>
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
-    <header role="banner"><div class="header-content"><h1>North African Amazigh Heritage</h1><p>A Journey Through Time: Tracing Genetic, Historical, and Cultural Roots in the Souss-Massa</p></div></header>
+        <header role="banner">
+        <div class="header-content">
+            <a class="site-brand" href="../index.html">
+                <span class="site-brand-mark" aria-hidden="true"></span>
+                <span class="site-brand-name">North African Amazigh Heritage</span>
+            </a>
+        </div>
+    </header>
     <nav class="main-nav"><div class="nav-container"><a href="../index.html">Home</a><a href="../lineage.html">Lineage History</a><a href="../genetics.html">Genetics</a><a href="../culture.html">Culture</a><a href="../research.html" class="active">Research</a><a href="../maps-sites.html">Maps &amp; Sites</a><a href="../glossary.html">Glossary</a><a href="../contact.html">Contact</a></div></nav>
 
     <main id="main-content" class="container" role="main">
@@ -74,7 +81,7 @@
                 <span class="paper-badge paper-badge-journal">Nature</span>
                 <span class="paper-date">July 2025</span>
             </div>
-            <h2 class="paper-title">Punic People Were Genetically Diverse with Almost No Levantine Ancestors</h2>
+            <h1 class="paper-title">Punic People Were Genetically Diverse with Almost No Levantine Ancestors</h1>
             <p class="paper-citation">Reich, D. et al. (2025). <em>Nature</em>, 643, 139-147.</p>
             <div class="paper-actions">
                 <a href="https://doi.org/10.1038/s41586-025-08913-3" target="_blank" rel="noopener noreferrer" class="paper-doi-link paper-doi-clay">View Full Paper (DOI) &rarr;</a>
@@ -82,14 +89,14 @@
         </section>
 
         <section class="card article-section">
-            <h3>Summary</h3>
+            <h2 class="article-head">Summary</h2>
             <p>This Nature study generated genome-wide ancient DNA for 210 individuals, including 196 from 14 Phoenician-Punic sites across the Levant, North Africa, Iberia, Sicily, Sardinia, and Ibiza.</p>
             <p>The authors found that Levantine Phoenicians contributed little direct ancestry to central and western Mediterranean Punic populations. Instead, most ancestry was related to groups from Sicily/Aegean contexts, with a substantial minority contribution from North Africa linked to Carthage.</p>
             <p>Across Punic settlements, the dataset shows consistently high genetic diversity and long-distance relatedness, indicating repeated mobility and mixing across the Mediterranean rather than closed founder populations.</p>
         </section>
 
         <section class="card article-section takeaways-clay">
-            <h3>Key Takeaways</h3>
+            <h2 class="article-head">Key Takeaways</h2>
             <ul class="takeaways-list">
                 <li>Large dataset: 210 genomes (196 from Phoenician-Punic contexts) across multiple Mediterranean regions</li>
                 <li>Levantine ancestry was limited in western Punic settlements despite strong cultural continuity</li>
@@ -99,7 +106,7 @@
         </section>
 
         <section class="card article-section">
-            <h3>Relevance to North African Genetics</h3>
+            <h2 class="article-head">Relevance to North African Genetics</h2>
             <p>For this site, the study is important because it quantifies North Africa's demographic influence beyond the Maghreb itself, particularly during the Iron Age through Carthaginian networks.</p>
             <p>It complements earlier prehistoric findings by showing that North African genetic impact continued into historical periods with maritime connectivity, not only through deep-time Holocene processes.</p>
         </section>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -195,4 +195,22 @@
     <changefreq>yearly</changefreq>
     <priority>0.6</priority>
   </url>
+  <url>
+    <loc>https://northafricanorigins.com/research/canary-islands-amazigh-history-2025.html</loc>
+    <lastmod>2026-09-06</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://northafricanorigins.com/research/demographic-modelling-amazigh-arab-2024.html</loc>
+    <lastmod>2026-09-06</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://northafricanorigins.com/research/mediterranean-islamic-dna-ibiza-2026.html</loc>
+    <lastmod>2026-09-06</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
Three finished summaries were merged into the **old fork** via its PR #8 and never reached the live site — roughly 590 lines of content sitting unpublished:

- Canary Islands Amazigh history — Santana et al. 2025 (*Scientific Reports*)
- Demographic modelling of Amazigh–Arab divergence — 2024
- Islamic-period Ibiza gene flow — 2026

Merging the fork wasn't an option: it predates this entire run, so a merge would have **reverted** everything. The three files and their `research.html` cards were extracted and brought forward instead.

## A gap in my own #50 work

While doing this I found the brand bar had only been applied to the **nine top-level pages**. The research articles' markup is minified onto single lines, so my header regex never matched them — all twelve still carried `<h1>North African Amazigh Heritage</h1>` in the header with no `<h1>` in `<main>`, contradicting the rule `DESIGN.md` now states.

So all twelve are aligned in one pass:

- Constant brand bar; the paper title becomes the page `<h1>` in `<main>`
- **Heading levels shifted up one** (h3→h2, h4→h3) so outlines are sequential. Visual sizes preserved via `.article-head` / `.article-subhead` — heading rank and visual weight are different things, and the old markup conflated them
- Imagery → WebP; social images → `og-card.jpg`; `theme-color` → palette brown
- The shared footer with secondary navigation
- The font `<link>`, for the three that predated it

## Two contrast failures that had never been audited

They exist **only** on article pages, which my earlier sweeps never covered:

| Element | Was | Ratio | Now |
|---|---|---|---|
| `.article-hero-caption` | `#6B7280` (Tailwind gray-500) | 4.39:1 | `--text-secondary` → 5.90:1 |
| `.paper-date` | `#8B7355` | 4.22:1 | `--text-secondary` → 6.12:1 |

## Verified

All twelve articles: exactly one `<h1>` in `<main>`, brand bar, footer nav, sequential headings, WebP imagery, no stale font or palette references. `research.html` lists 12 papers with its count label corrected; `sitemap.xml` carries the three new URLs.

Lighthouse mobile **100 across all four categories** on a new article.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMR1RF82fkDXuVPQF8xk4G