### PR TITLE
fix(a11y): hide the skip link until it is focused

### DIFF
--- a/changelog/unreleased/fix-skip-link-hidden-until-focus.md
+++ b/changelog/unreleased/fix-skip-link-hidden-until-focus.md
@@ -1,0 +1,2 @@
+### Fixed
+- The "Skip to main content" link no longer shows as a brown sliver in the top-left corner of every page. `.skip-to-main` was declared twice in `css/styles.css`; the second declaration replaced the working off-screen offset with `top: -40px`, which the link's own height out-ran. Both declarations, and the separate `.skip-link` class used by the research articles, are now one rule that hides the link with the clip-based visually-hidden pattern and reveals it in a single consistent position on keyboard focus (#75)

--- a/css/styles.css
+++ b/css/styles.css
@@ -933,22 +933,40 @@ img {
     color: var(--accent-text);
 }
 
-/* Skip to main content */
-.skip-to-main {
+/* Skip to main content — the single source of truth for both class names
+   used across the site (.skip-to-main on most pages, .skip-link under research/).
+   Visually hidden until it receives keyboard focus: no offsets to get wrong, so
+   it can never peek back onto the page the way a negative `top` does. */
+.skip-to-main,
+.skip-link {
     position: absolute;
-    left: -9999px;
-    z-index: 999;
-    padding: 1rem;
-    background: var(--primary-dark);
-    color: white;
-    text-decoration: none;
-    border-radius: var(--radius-md);
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
 }
 
-.skip-to-main:focus {
+.skip-to-main:focus,
+.skip-link:focus {
+    top: 1rem;
     left: 50%;
     transform: translateX(-50%);
-    top: 1rem;
+    width: auto;
+    height: auto;
+    overflow: visible;
+    clip: auto;
+    clip-path: none;
+    padding: 1rem;
+    background: var(--accent-solid);
+    color: #fff;
+    text-decoration: none;
+    border-radius: var(--radius-md);
+    z-index: 1000;
 }
 
 /* ========================================
@@ -1568,42 +1586,6 @@ footer a:hover {
 img[alt] {
     max-width: 100%;
     height: auto;
-}
-
-/* Skip to main content link for accessibility */
-.skip-to-main {
-    position: absolute;
-    top: -40px;
-    left: 6px;
-    background: var(--primary-color);
-    color: white;
-    padding: 8px;
-    text-decoration: none;
-    border-radius: 4px;
-    z-index: 1000;
-    transition: top 0.3s ease;
-}
-
-.skip-to-main:focus {
-    top: 6px;
-}
-
-/* Skip link - alternate class name for same functionality */
-.skip-link {
-    position: absolute;
-    top: -40px;
-    left: 6px;
-    background: var(--accent-solid);
-    color: white;
-    padding: 8px;
-    text-decoration: none;
-    border-radius: 4px;
-    z-index: 1000;
-    transition: top 0.3s ease;
-}
-
-.skip-link:focus {
-    top: 6px;
 }
 
 /* Enhanced focus indicators for accessibility */


### PR DESCRIPTION
Closes #75

## What was wrong

`.skip-to-main` was declared twice in `css/styles.css` — once in the accessibility block around line 937, once again at line 1574. The later declaration won and replaced the working `left: -9999px` with `top: -40px; left: 6px`. The link is slightly taller than 40px (8px padding plus line-height), so its bottom edge stayed on screen: a brown sliver in the top-left corner of every page.

On focus the two `:focus` rules combined rather than one replacing the other — the later supplied `top`, the earlier still supplied `left: 50%` and `transform: translateX(-50%)` — which is why the link jumped to the top-centre instead of appearing where it had been sitting.

The `research/*.html` pages use a second class name, `.skip-link`, which carried the same fragile `top: -40px` technique in its own block.

## What changed

Both `.skip-to-main` declarations and the `.skip-link` block collapse into one rule pair covering both class names, so the two page families behave identically. The link is hidden with the clip-based visually-hidden pattern (1px box, `clip-path: inset(50%)`, no background) rather than a negative offset the element's own height can out-run, and unclips into a single consistent position on keyboard focus.

The skip link itself stays — it is WCAG 2.4.1 (Bypass Blocks), and it costs sighted mouse users nothing when it works correctly.

## Verification

- `.skip-to-main` now resolves to one rule pair in `css/styles.css` instead of two conflicting ones
- All 26 pages carrying a skip link point at `#main-content`, which exists on every one of them
- Rendered before/after in headless Chrome at 1200x700: the brown sliver is present in the top-left at rest before the change and gone after it
- Focused the link on both page families — `index.html` (`.skip-to-main`) and `research/green-sahara-ancient-dna-2025.html` (`.skip-link`) — and both now reveal the same burnt-sienna panel in the same position

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgzHfiCZNyLRBh9dbL9xDn