### PR TITLE
design: bright flat-colour poster identity, piloted on two pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,17 +14,17 @@ This is a **no-build static site** — plain HTML, CSS, and vanilla JS. No packa
 
 - **Edit and preview directly** — open any `.html` file in a browser
 - **Deployment** — automatic via GitHub Pages from main branch
-- **External deps (CDN only):** Chart.js, Mermaid, Google Fonts (Literata, Archivo, IBM Plex Mono)
+- **External deps (CDN only):** Google Fonts (Bricolage Grotesque, Instrument Sans, IBM Plex Mono, Noto Sans Tifinagh on migrated pages; Literata and Archivo on legacy pages). Chart.js and Mermaid are used only by pages still on the legacy stylesheet
 - **Contact form:** Formspree (ID: myzbzgjn)
 
 ## Architecture
 
 - `index.html`, `lineage.html`, `genetics.html`, `culture.html`, `research.html`, `contact.html`,
   `start-here.html`, `glossary.html`, `maps-sites.html`, `limitations.html` — the site pages
-- `research/*.html` — nine paper summaries
-- `css/styles.css` — single stylesheet with CSS custom properties in one `:root`
+- `research/*.html` — twelve paper summaries
+- `css/main.css` — the current design system (see `DESIGN.md`). `css/styles.css` is the legacy stylesheet still serving un-migrated pages; it is deleted when the last page moves over. A page loads one or the other, never both
 - `js/reading-aids.js` — TOC rail, reading progress, back-to-top
-- `img/` — WebP imagery (plus `og-card.jpg` for social and `site-logo-mark.png`)
+- `img/` — legacy WebP imagery (plus `og-card.jpg` for social). Migrated pages use authored inline SVG diagrams instead of photographs — see the Imagery section of `DESIGN.md`
 - `docs/` — research notes and SEO documentation
 - Chart.js and Mermaid configs are inline per page; shared behaviour is in `js/reading-aids.js`
 
@@ -46,7 +46,7 @@ stylesheet; that is what #59 resolved. Do not reintroduce a second copy.
 - Date format with context: "~400 BCE (2,400 years before present)"
 - Geographic: "Souss-Massa" (primary), "Souss Valley" (descriptive)
 - Language reference: "Tachelhit" (the specific Amazigh language)
-- Tone: Scholarly yet accessible, data-driven, culturally respectful
+- Tone: written for a curious sixteen-year-old — short sentences, concrete nouns, the finding before the method. The evidence stays scholarly: date ranges, hedging and citations are never cut to shorten a page
 
 ## SEO Checklist (for any page changes)
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -8,57 +8,87 @@ in the same commit. A rule nobody enforces is worse than no rule.
 
 ---
 
+## What this site is trying to be
+
+A bright, flat, poster-like site about one Amazigh family's deep ancestry, built for
+readers who are curious but not academic — teenagers and young adults first, specialists
+second. The evidence is scholarly. The presentation is not.
+
+The previous system failed on this point in a specific, diagnosable way: one hue
+(warm brown) across every surface, a reading serif at every size, and a uniform grid
+of equal cards. That is the visual signature of a generated document, and it read as a
+journal paper. The corrective is not a different single hue. It is **four colours with
+real hue separation, a hard split between display and reading type, and blocks of
+deliberately unequal weight.**
+
+---
+
 ## Colour
 
-The palette is warm earth tones. The important part is not the hues — it is that
-**each hue has one role**, because the brand colours cannot legally carry text.
+The palette is the **Amazigh flag** — sea blue, mountain green, sand yellow, and the
+red of the yaz (ⵣ) — on bright paper with near-black ink.
 
-### By role
+This is not decoration borrowed from somewhere else. These are the colours the subject
+of the site already uses to identify itself, which is why the palette is allowed to be
+loud: it is not a mood, it is a flag.
 
-| Role | Token | Value | Use for |
+### Tokens
+
+| Role | Token | Value | Contrast |
 |---|---|---|---|
-| Text accent | `--accent-text` | `#94571B` | Links, nav, headings, any coloured text |
-| Text accent, hover | `--accent-text-hover` | `#8F531A` | Hover state on the above |
-| Solid fill | `--accent-solid` | `#8B4513` | Buttons and pills carrying white text |
-| Decoration | `--primary-terracotta` | `#CD7F32` | Borders, rails, dividers, decorative fills |
-| Decoration | `--accent-ochre` / `#D4A629` | | Gradients, rails — **never text** |
-| Ink | `--primary-dark` | `#3E2723` | Headings and body ink |
-| Ground | `--background` | `#FAF8F4` | Page background |
+| Paper | `--paper` | `#FFFCF5` | ground |
+| On colour | `--on-colour` | `#FFFFFF` | type on sea/mountain/yaz/ink |
+| Paper, sunk | `--paper-sunk` | `#F6F1E6` | band ground |
+| Ink | `--ink` | `#16130F` | 18.07:1 on paper |
+| Ink, quiet | `--ink-quiet` | `#57504A` | 7.36:1 on paper |
+| Sea | `--sea` | `#1746C4` | 7.75:1 w/ white · 7.56:1 as text |
+| Mountain | `--mountain` | `#0B7A41` | 5.42:1 w/ white · 5.29:1 as text |
+| Yaz | `--yaz` | `#D11810` | 5.46:1 w/ white · 5.32:1 as text |
+| Sand | `--sand` | `#FFC61E` | 11.77:1 w/ ink · **never white** |
 
-**The rule that matters:** `#CD7F32` scores 2.95:1 and `#D4A629` scores 2.12:1 against
-the page ground. Both fail WCAG AA for text. They are decoration only. Text takes
-`--accent-text`; white-on-colour takes `--accent-solid` (7.10:1).
+### The rule that matters
 
-Never introduce a colour by literal in HTML or CSS. Add a token or use an existing one.
+**Sea, mountain and yaz are dual-role.** Each one clears AA both as white-on-colour and
+as colour-on-paper, so the same token fills a block and sets a link. That is the whole
+simplification over the old system, where no brand colour could legally carry text and
+every colour needed a second "text-safe" twin.
 
-### Blue
+**Sand is a fill, and only ever a fill.** It scores 1.63:1 against white and 1.54:1 as
+text on paper. Sand blocks carry ink. Sand never sets type on paper, never carries white,
+and never appears as a link colour. If you find yourself wanting yellow text, you want
+ink on a sand block instead.
 
-No blue in chrome, type or decoration. This is not because blue is ugly — it is because
-a previous incarnation used stock blue gradients that read as generic.
+Never introduce a colour by literal in HTML or CSS — including inside inline SVG, where
+`fill` and `stroke` take `var(--token)` like anything else. White is `--on-colour`, not
+`#fff`. Add a token or use an existing one; the only hex values in the stylesheet are the
+token definitions themselves.
 
-Be aware of the trap that produced: constraining the whole site to one hue is itself the
-most recognisable machine-generated look, and it briefly made the site *more* templated,
-not less. The answer is role separation and typography, not more brown.
+### On blue
+
+Blue is not merely allowed, it leads. The previous system banned it because an early
+incarnation used stock blue gradients that read as generic — but the fix for a generic
+blue is a *specific* blue, not the absence of one. `--sea` is the flag's blue and it
+carries the brand.
 
 ### Data visualisation
 
-Charts and diagrams follow a **luminance-ordered** ramp, because with hue fixed to one
-family only lightness separates series:
+Four hues with genuine separation, so series are distinguished by hue, not by lightness:
 
 ```
-#8B4513  L = 0.098   burnt sienna
-#CD7F32  L = 0.284   terracotta
-#E2A36B  L = 0.434   warm sand
+--sea       #1746C4     paternal line, Africa, deep time
+--yaz       #D11810     maternal line, Europe, migration
+--mountain  #0B7A41     land, place, the living present
+--sand      #FFC61E     emphasis and ground only, never a series
 ```
 
-Two series take the ends of that ramp (3.27:1 in greyscale).
+Series colour is stable across the whole site: **the father's line is always sea, the
+mother's line is always yaz.** A reader who learns that on the homepage should not have
+to relearn it on any other page.
 
-**Colour is never the only cue.** Every series also carries a non-colour identifier —
-a dash pattern, a point marker, or a distinct border. This is required, not optional.
-
-> Open question (issue #57): whether to license a small desaturated categorical set for
-> data encoding only. Three or more series are weakly separated under the current
-> constraint. Until that is decided, keep to the ramp above.
+**Colour is never the only cue.** Every series also carries a non-colour identifier — a
+dash pattern, a distinct marker shape, or a text label placed directly on the mark.
+This is required, not optional, and it is what keeps the diagrams readable in greyscale
+and for colour-blind readers.
 
 ---
 
@@ -66,23 +96,63 @@ a dash pattern, a point marker, or a distinct border. This is required, not opti
 
 | Role | Family | Notes |
 |---|---|---|
-| Reading | **Literata** | Body copy, prose. Drawn for long-form reading on screen |
-| Chrome | **Archivo** | Headings, nav, buttons, TOC, table headers, kickers |
-| Technical | **IBM Plex Mono** | Haplogroup notation, dates, identifiers |
+| Display | **Bricolage Grotesque** | Headings, numbers, kickers, buttons. 700–800, tight tracking |
+| Reading | **Instrument Sans** | Body copy. Humanist, quiet, gets out of the way |
+| Technical | **IBM Plex Mono** | Haplogroup notation, dates, coordinates, identifiers |
+| Tifinagh | **Noto Sans Tifinagh** | The ⵣ yaz and any Tifinagh glyph. Subset to the glyphs used |
 
-The serif/grotesque split carries meaning: **what you read is Literata, what you
-navigate by is Archivo.** Do not blur that.
+The split carries meaning: **what shouts is Bricolage, what you read is Instrument,
+what is a precise identifier is Plex Mono.** Do not blur that.
 
 - Load fonts with a `<link>` in `<head>`, never an `@import` (render-blocking).
 - Always declare a real fallback stack. Three silent fallbacks to an unloaded `Lexend`
   shipped for months because nobody checked.
-- Body: 17px / 1.7. Running prose gets `max-width: 72ch`.
-- Headings use `text-wrap: balance`.
+- **Tifinagh glyphs need Noto Sans Tifinagh or they render as tofu.** Any `ⵣ` in markup
+  must be inside an element that resolves to that family. The Google Fonts request is
+  subset with `&text=` so it costs well under 5 KB.
+- Body: 17px / 1.65, `max-width: 68ch` on running prose.
+- Display headings use `text-wrap: balance` and negative tracking (`-0.03em` and tighter
+  as size grows). At poster sizes, default tracking looks loose and accidental.
+- Display type is set in sentence case, not all-caps, except kickers and stat labels,
+  which are all-caps at small sizes with positive tracking.
 - **Headings are text.** Never `display: flex` on a heading — it turns a text node and a
   nested `<span>` into two side-by-side items, which broke the hero twice.
 
 Do not use Inter or Space Grotesk. Both are strongly associated with machine-generated
 layout, and using them together is a tell.
+
+---
+
+## Form language
+
+Three rules produce the poster feel. They are cheap to state and easy to violate.
+
+1. **Flat.** No shadows, no gradients, no blurs, no glass. A block is one solid colour.
+   Depth is communicated by colour weight and scale, never by a drop shadow.
+2. **Hard-edged.** Border radius is `0` on blocks, bands and buttons. The only radius on
+   the site is the fully-round `--radius-dot` used for legend markers.
+3. **Unequal.** Blocks in a group must differ in size, colour or weight. A row of four
+   identical cards is the failure mode this design replaced; if a grid looks like a table
+   of equals, it is wrong.
+
+Separation comes from **colour change and the stripe rule**, never from a border on
+every side of every box.
+
+### The stripe
+
+The site's one ornament is a band of unequal vertical stripes in the four palette
+colours (`.stripe`). It is drawn from the striated `haik` and `tahaikt` textiles woven by
+Ait Moussa women, whose stripe patterns are — unusually among Amazigh weaving traditions —
+purely decorative rather than protective. An ornament that is openly ornamental is the
+right one for this site to borrow.
+
+Stripe widths are deliberately irregular. Do not make them even.
+
+### The mark
+
+`ⵣ` — yaz, the Tifinagh letter that stands for *Amazigh*, "free people". It appears as
+the brand mark in the header and as the section marker on content pages. It is set in
+Noto Sans Tifinagh, in `--yaz` on paper or white on colour.
 
 ---
 
@@ -97,72 +167,115 @@ layout, and using them together is a tell.
 
 ## Layout
 
-- Container max-width 1200px.
+- Container max-width 1180px; full-bleed colour bands break out of it, their content does not.
 - Grids use `minmax(0, 1fr)`, never bare `1fr` — `1fr` cannot shrink below min-content and
   will push the page sideways on a phone.
 - Wide content (tables, diagrams) scrolls inside its own container. The body never scrolls
   horizontally, at any width down to 320px.
-- Breakpoints: 1024px (rail/desktop), 768px (tablet), 640px (stacked).
-- Content pages get a sticky TOC rail ≥1024px. Landing pages opt out with
-  `data-reading-aids="off"`.
+- Breakpoints: 1024px (desktop), 768px (tablet), 560px (stacked).
+- Vertical rhythm is carried by band padding, not by margins between arbitrary elements.
 
 ## Components
 
 Only these exist. Do not invent variants without adding them here.
 
-- `.card` — the content container. Not everything needs to be one.
-- `.home-section-card` / `.home-section-lead` — homepage entries. **One lead, the rest
-  quiet.** The lead carries the only accent rail on the page.
-- `.btn` / `.btn-copper` / `.btn-outline` — min-height 44px. Buttons are not links: keep
-  them out of any `.card a` colour rule.
-- `.toc-card` — sticky rail on desktop, vertical list on mobile.
+- `.band` — a full-bleed horizontal section. `.band--sea` / `--yaz` / `--mountain` /
+  `--sand` / `--sunk` set its ground. Consecutive bands must not repeat a ground.
+- `.block` — a solid rectangle of colour carrying text. `.block--lead` is the oversized one.
+- `.stripe` — the woven rule. Section separator and hero ornament.
+- `.kicker` — all-caps mono or display label above a heading.
+- `.stat` — a big display number with a small label. Numbers are the loudest type on the site.
+- `.btn` — square, solid, min-height 48px. `.btn--ghost` is the outline variant.
+- `.door` — the large tappable entry blocks (DNA / Land / Language).
+- `.figure` — an authored SVG diagram with a caption. Never a photograph.
+- `.note` — the honesty callout: what the evidence does not support.
 - `.page-title`, `.page-updated`, `.sourcing-note`.
 
-Radius 3–8px. No pill shapes. Shadows subtle and rare — border, fill, radius and shadow
-each say "separate object", so spend them by role rather than stamping every block.
+## Imagery
 
----
+**Diagrams, not photographs.** Every explanatory visual is authored inline SVG committed
+to the repo: timelines, haplogroup trees, maps, comparison schemas.
+
+This is a hard constraint with a practical cause — the site's photographs were generated
+under a Stable Diffusion subscription that has lapsed, so that library cannot be extended
+and the existing images cannot be matched. It is also the better answer: an authored
+diagram is editable forever, weighs a few kilobytes, scales to any screen, inherits the
+palette tokens, and adapts to the reader's theme. A generated photograph of a place does
+none of that and quietly implies a documentary authority it has not earned.
+
+- Inline SVG, not `<img src="*.svg">`, so diagrams inherit CSS custom properties.
+- Every diagram carries `role="img"` and an `<title>`, plus a text caption that states
+  the finding — not "Figure 3" but the sentence the diagram exists to make.
+- Any diagram encoding data follows the data-visualisation rules above.
+- Photographs are permitted only where the subject is a real, specific place or object
+  and the image is genuine. Generated imagery is not permitted anywhere.
+- Social images stay JPEG (`og-card.jpg`, 1200×630) — crawler support for WebP is uneven.
 
 ## Content
 
 - **Amazigh** first, "Berber" in parentheses on first mention.
-- Haplogroups in full: `E-PF2546`, `H1-T16189C!`.
-- Dates carry their range: "~11,400 years ago (range ~9,000–13,700)". A midpoint alone
+- Haplogroups in full: `E-PF2546`, `H1-T16189C!`, set in Plex Mono.
+- Dates carry their range: "~11,000 years ago (range ~8,000–11,000)". A midpoint alone
   overstates the evidence.
-- Hedge honestly — "approximately", "estimated", "debated". The genetics pages already
-  do this well; hold everything else to that standard.
-- **No emoji in headings.** 77 had to be removed.
-- Cite at the point of assertion, with a DOI. Where content is not from published
-  literature, say so — see the sourcing note on `culture.html`.
+- Hedge honestly — "approximately", "estimated", "debated".
+- Cite at the point of assertion. Where content is not from published literature, say so.
+- **No emoji.** Not in headings, not in body, not in nav. The yaz and the stripe are the
+  site's ornament; emoji would compete with them and cheapen both. 77 had to be removed once.
 - Every page shows a visible "Last updated", matched to JSON-LD `dateModified` and
-  `sitemap.xml`. "Updated", not "reviewed": the date reflects a file change, and
-  "reviewed" would claim more.
+  `sitemap.xml`. "Updated", not "reviewed": the date reflects a file change.
+
+### Register, and the trap in shortening
+
+Write for a curious sixteen-year-old: short sentences, concrete nouns, the finding before
+the method. Lead with the claim, then support it.
+
+**Concision comes from structure, never from stripping the qualifications.** The date
+ranges, the DOIs and the words "estimated" and "debated" are not padding — they are what
+separates this site from the confident nonsense that fills the rest of the genetic-ancestry
+internet. Cut a page by moving detail to a diagram, a deeper page or a disclosure, not by
+deleting the range from a date or the citation from a claim.
+
+Target: **no more than ~900 words of running prose** per top-level page. Tables,
+figure captions and source lists are scanned rather than read and are counted
+separately — a five-row comparison table does not cost the reader what 180 words of
+prose would. Measure the prose, not the raw word count, and do not game the rule by
+turning prose into a table that nobody would naturally tabulate.
 
 ## Accessibility
 
 The floor, not the goal. Lighthouse mobile accessibility must be **100 with zero
 failures** before merge.
 
-- 4.5:1 for normal text, 3:1 for large. Check against the actual card ground, which is
-  darker than the page ground.
-- Visible focus on everything interactive.
-- Touch targets ≥44px.
-- Alt text on every image, with `width`/`height` to prevent layout shift.
+- 4.5:1 for normal text, 3:1 for large. Check against the actual block ground, not the page.
+- Visible focus on everything interactive. On colour blocks the focus ring switches to
+  paper so it stays visible.
+- Touch targets ≥48px.
+- Colour is never the only carrier of meaning — see the data-visualisation rules.
+- `prefers-reduced-motion` is respected; all transitions collapse to none.
+- Alt text on every image, with `width`/`height` to prevent layout shift. Inline SVG uses
+  `role="img"` + `<title>` instead.
 
 ## Performance
 
-- Images: WebP, sized to roughly 2× their real CSS display width. No JPEG/PNG fallbacks —
-  shipping both formats defeats the point.
-- Photographs q82; maps and charts q90, since they carry fine text.
-- Social images stay JPEG (`og-card.jpg`, 1200×630) — crawler support for WebP is uneven.
-- The LCP image is eager, preloaded, `fetchpriority="high"`. `loading="lazy"` is for
-  below-fold images only.
-- No page ships more than ~600 KB of imagery.
+- No page ships more than ~250 KB of imagery. Diagrams are inline SVG and cost almost nothing.
+- Any remaining photographs: WebP, sized to roughly 2× their real CSS display width,
+  q82 for photographs. No JPEG/PNG fallbacks.
+- The LCP element is text, not an image. Nothing above the fold should need to download
+  before the page reads.
+- Fonts: four families, all variable or subset, loaded from one `<link>` with `display=swap`.
+
+## Migration state
+
+This system ships in `css/main.css`. The previous system's `css/styles.css` is still
+served by the pages not yet migrated, and is deleted when the last page moves over.
+A page uses one stylesheet or the other, never both.
+
+Migrated: `index.html`, `lineage.html`.
 
 ## Working on this repo
 
 No build step. Plain HTML, CSS and vanilla JS; edit and open in a browser. Deployment is
 automatic from `main` via GitHub Pages.
 
-Before opening a PR: run Lighthouse on the pages you touched, and check 390px for
+Before opening a PR: run Lighthouse on the pages you touched, and check 320px for
 horizontal overflow.

--- a/changelog/unreleased/design-flat-poster-identity-pilot.md
+++ b/changelog/unreleased/design-flat-poster-identity-pilot.md
@@ -1,0 +1,8 @@
+### Changed
+- New visual identity, piloted on the homepage and `lineage.html`: a bright flat-colour poster system built on the Amazigh flag palette — sea blue, mountain green, sand yellow and yaz red — with Bricolage Grotesque for display, Instrument Sans for reading, and the yaz (ⵣ) as the brand mark. Retiring the old "no blue" rule is what made the flag's own colours available. `DESIGN.md` was rewritten against it; the accessibility, performance and structural rules carried over unchanged (#77)
+- `lineage.html` cut from roughly 2,100 words of prose to 824, with the argument now carried by a vertical deep-time timeline, an E-PF2546 frequency chart and a scored comparison of the five competing explanations for how a European maternal line reached North Africa. No date range, hedge or citation was dropped to achieve it (#77)
+- Site ornament is now a band of irregular stripes taken from the striated `haik` and `tahaikt` textiles woven by Ait Moussa women, whose patterns are decorative rather than protective (#77)
+
+### Added
+- `css/main.css`, the new design system. `css/styles.css` continues to serve the 21 pages not yet migrated and is deleted when the last one moves over (#77)
+- Authored inline SVG diagrams in place of photography on the migrated pages. The site's images were generated under a Stable Diffusion subscription that has lapsed, so the library could not be extended; authored diagrams cost nothing, inherit the palette tokens and stay editable (#77)

--- a/css/main.css
+++ b/css/main.css
@@ -1,0 +1,835 @@
+/* ==========================================================================
+   North African Origins — design system
+   Implements DESIGN.md. If you change a rule here, change DESIGN.md in the
+   same commit.
+
+   Legacy note: css/styles.css still serves the pages not yet migrated to this
+   system. It is deleted when the last page moves over.
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Tokens
+   -------------------------------------------------------------------------- */
+
+:root {
+    /* Amazigh flag palette. Contrast figures in DESIGN.md.
+       Sea, mountain and yaz are dual-role: they fill a block AND set text.
+       Sand is a fill only — it never carries white and never sets type. */
+    --paper: #FFFCF5;
+    /* Type on a colour ground. Fixed white — the counterpart of the four fills. */
+    --on-colour: #FFFFFF;
+    --paper-sunk: #F6F1E6;
+    --ink: #16130F;
+    --ink-quiet: #57504A;
+
+    --sea: #1746C4;
+    --mountain: #0B7A41;
+    --yaz: #D11810;
+    --sand: #FFC61E;
+
+    /* Type */
+    --font-display: "Bricolage Grotesque", "Archivo", system-ui, sans-serif;
+    --font-body: "Instrument Sans", system-ui, -apple-system, sans-serif;
+    --font-mono: "IBM Plex Mono", ui-monospace, "SFMono-Regular", monospace;
+    --font-tifinagh: "Noto Sans Tifinagh", var(--font-display);
+
+    --t-xs: 0.75rem;
+    --t-sm: 0.875rem;
+    --t-body: 1.0625rem;
+    --t-lead: clamp(1.15rem, 0.95rem + 0.9vw, 1.45rem);
+    --t-h3: clamp(1.3rem, 1.1rem + 1vw, 1.7rem);
+    --t-h2: clamp(1.9rem, 1.3rem + 2.6vw, 3rem);
+    --t-h1: clamp(2.5rem, 1.2rem + 5.6vw, 5rem);
+    --t-mega: clamp(3.2rem, 1rem + 9.5vw, 8rem);
+
+    /* Space */
+    --gap: clamp(1rem, 0.7rem + 1.4vw, 1.75rem);
+    --band-y: clamp(3rem, 2rem + 4vw, 6rem);
+    --container: 1180px;
+
+    /* Form language: flat and hard-edged. The only radius on the site. */
+    --radius-dot: 50%;
+    --rule: 2px solid var(--ink);
+}
+
+/* --------------------------------------------------------------------------
+   2. Base
+   -------------------------------------------------------------------------- */
+
+*,
+*::before,
+*::after { box-sizing: border-box; }
+
+html {
+    -webkit-text-size-adjust: 100%;
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--font-body);
+    font-size: var(--t-body);
+    line-height: 1.65;
+    font-synthesis-weight: none;
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+}
+
+img,
+svg { max-width: 100%; }
+
+img { height: auto; }
+
+a { color: var(--sea); }
+
+a:hover { text-decoration-thickness: 2px; }
+
+::selection {
+    background: var(--sand);
+    color: var(--ink);
+}
+
+/* --------------------------------------------------------------------------
+   3. Typography
+   -------------------------------------------------------------------------- */
+
+h1, h2, h3, h4 {
+    font-family: var(--font-display);
+    font-weight: 800;
+    line-height: 1.02;
+    letter-spacing: -0.03em;
+    text-wrap: balance;
+    margin: 0 0 0.5em;
+}
+
+h1 { font-size: var(--t-h1); letter-spacing: -0.045em; }
+h2 { font-size: var(--t-h2); letter-spacing: -0.035em; }
+h3 { font-size: var(--t-h3); }
+h4 { font-size: 1.05rem; letter-spacing: -0.02em; }
+
+p { margin: 0 0 1em; }
+
+.prose { max-width: 68ch; }
+
+.prose > p:last-child { margin-bottom: 0; }
+
+.lead {
+    font-size: var(--t-lead);
+    line-height: 1.45;
+    max-width: 40ch;
+}
+
+.kicker {
+    font-family: var(--font-mono);
+    font-size: var(--t-xs);
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    margin: 0 0 0.9rem;
+    display: block;
+}
+
+/* Haplogroup notation, dates, identifiers. */
+.hg {
+    font-family: var(--font-mono);
+    font-size: 0.92em;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    white-space: nowrap;
+}
+
+.yaz-mark {
+    font-family: var(--font-tifinagh);
+    line-height: 1;
+    font-weight: 400;
+}
+
+/* --------------------------------------------------------------------------
+   4. Layout
+   -------------------------------------------------------------------------- */
+
+.container {
+    width: min(100% - 2.5rem, var(--container));
+    margin-inline: auto;
+}
+
+.band {
+    padding-block: var(--band-y);
+    background: var(--paper);
+}
+
+.band--sunk     { background: var(--paper-sunk); }
+.band--sea      { background: var(--sea); }
+.band--mountain { background: var(--mountain); }
+.band--yaz      { background: var(--yaz); }
+.band--sand     { background: var(--sand); }
+.band--ink      { background: var(--ink); }
+.band--tight    { padding-block: clamp(2rem, 1.4rem + 2.4vw, 3.25rem); }
+
+/* Sea, mountain, yaz and ink grounds carry white type. */
+.band--sea,
+.band--mountain,
+.band--yaz,
+.band--ink {
+    color: var(--on-colour);
+}
+
+.band--sea a,
+.band--mountain a,
+.band--yaz a,
+.band--ink a { color: var(--on-colour); }
+
+/* Sand carries ink — never white. */
+.band--sand { color: var(--ink); }
+.band--sand a { color: var(--ink); }
+
+/* --------------------------------------------------------------------------
+   5. The stripe — the site's one ornament.
+   Irregular widths, after the striated Ait Moussa tahaikt. Do not even them out.
+   -------------------------------------------------------------------------- */
+
+.stripe {
+    height: 12px;
+    border: 0;
+    margin: 0;
+    background: linear-gradient(90deg,
+        var(--sea) 0 6%, var(--sand) 6% 10%, var(--ink) 10% 12%,
+        var(--yaz) 12% 21%, var(--paper) 21% 24%, var(--mountain) 24% 33%,
+        var(--sand) 33% 39%, var(--sea) 39% 43%, var(--yaz) 43% 46%,
+        var(--mountain) 46% 57%, var(--sand) 57% 62%, var(--ink) 62% 64%,
+        var(--sea) 64% 73%, var(--yaz) 73% 78%, var(--sand) 78% 85%,
+        var(--mountain) 85% 91%, var(--sea) 91% 100%);
+}
+
+.stripe--tall { height: 20px; }
+
+/* --------------------------------------------------------------------------
+   6. Header, nav, footer
+   -------------------------------------------------------------------------- */
+
+.site-header {
+    background: var(--paper);
+    border-bottom: var(--rule);
+}
+
+.site-header__inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding-block: 0.85rem;
+}
+
+.brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    text-decoration: none;
+    color: var(--ink);
+    font-family: var(--font-display);
+    font-weight: 800;
+    font-size: 1.05rem;
+    letter-spacing: -0.03em;
+}
+
+.brand__mark {
+    display: grid;
+    place-items: center;
+    width: 34px;
+    height: 34px;
+    background: var(--yaz);
+    color: var(--on-colour);
+    font-family: var(--font-tifinagh);
+    font-size: 1.15rem;
+    line-height: 1;
+}
+
+.nav {
+    background: var(--ink);
+    border-bottom: var(--rule);
+}
+
+.nav__list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.nav__link {
+    display: block;
+    padding: 0.85rem 1.1rem;
+    color: var(--on-colour);
+    text-decoration: none;
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 0.95rem;
+    letter-spacing: -0.01em;
+    min-height: 48px;
+    display: flex;
+    align-items: center;
+}
+
+.nav__link:hover { background: var(--sea); }
+
+.nav__link[aria-current="page"] {
+    background: var(--sand);
+    color: var(--ink);
+}
+
+.breadcrumb {
+    font-size: var(--t-sm);
+    color: var(--ink-quiet);
+    padding-block: 0.9rem;
+}
+
+.breadcrumb a { color: var(--ink-quiet); }
+
+.site-footer {
+    background: var(--ink);
+    color: var(--on-colour);
+    padding-block: clamp(2.5rem, 2rem + 2vw, 4rem);
+}
+
+.site-footer a { color: var(--on-colour); }
+
+.site-footer__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 190px), 1fr));
+    gap: var(--gap);
+}
+
+.site-footer h2 {
+    font-size: 0.8rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font-family: var(--font-mono);
+    font-weight: 600;
+    margin-bottom: 0.8rem;
+}
+
+.site-footer ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.4rem;
+    font-size: var(--t-sm);
+}
+
+.site-footer__base {
+    margin-top: 2.5rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.25);
+    font-size: var(--t-sm);
+    color: rgba(255, 255, 255, 0.75);
+}
+
+/* --------------------------------------------------------------------------
+   7. Buttons — square, solid, 48px floor
+   -------------------------------------------------------------------------- */
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-height: 48px;
+    padding: 0.75rem 1.4rem;
+    background: var(--ink);
+    color: var(--paper);
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 1rem;
+    letter-spacing: -0.01em;
+    text-decoration: none;
+    border: 2px solid var(--ink);
+    cursor: pointer;
+    transition: transform 0.12s ease, background-color 0.12s ease;
+}
+
+.btn:hover {
+    background: var(--sea);
+    border-color: var(--sea);
+    transform: translateX(3px);
+}
+
+.btn--ghost {
+    background: transparent;
+    color: var(--ink);
+}
+
+.btn--ghost:hover {
+    background: var(--ink);
+    color: var(--paper);
+    border-color: var(--ink);
+}
+
+/* On colour grounds the button inverts to paper. */
+.band--sea .btn,
+.band--mountain .btn,
+.band--yaz .btn,
+.band--ink .btn {
+    background: var(--paper);
+    color: var(--ink);
+    border-color: var(--paper);
+}
+
+.band--sea .btn:hover,
+.band--mountain .btn:hover,
+.band--yaz .btn:hover,
+.band--ink .btn:hover {
+    background: var(--sand);
+    border-color: var(--sand);
+    color: var(--ink);
+}
+
+/* --------------------------------------------------------------------------
+   8. Blocks, stats, doors
+   -------------------------------------------------------------------------- */
+
+.block {
+    padding: clamp(1.25rem, 1rem + 1.4vw, 2.25rem);
+    background: var(--paper-sunk);
+    color: var(--ink);
+}
+
+.block--sea      { background: var(--sea); color: var(--on-colour); }
+.block--mountain { background: var(--mountain); color: var(--on-colour); }
+.block--yaz      { background: var(--yaz); color: var(--on-colour); }
+.block--sand     { background: var(--sand); color: var(--ink); }
+.block--ink      { background: var(--ink); color: var(--on-colour); }
+
+.block--sea a,
+.block--mountain a,
+.block--yaz a,
+.block--ink a { color: var(--on-colour); }
+
+.block h2,
+.block h3 { margin-top: 0; }
+
+/* Stats — the loudest type on the site. */
+.stat-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 170px), 1fr));
+    gap: 2px;
+    background: var(--ink);
+    border: var(--rule);
+}
+
+.stat {
+    background: var(--paper);
+    padding: clamp(1.1rem, 0.9rem + 1vw, 1.75rem);
+}
+
+.stat__num {
+    display: block;
+    font-family: var(--font-display);
+    font-weight: 800;
+    font-size: clamp(2.1rem, 1.2rem + 3.4vw, 3.4rem);
+    line-height: 0.95;
+    letter-spacing: -0.05em;
+}
+
+.stat__label {
+    display: block;
+    overflow-wrap: break-word;
+    margin-top: 0.55rem;
+    font-family: var(--font-mono);
+    font-size: var(--t-xs);
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-quiet);
+}
+
+.stat--sea .stat__num      { color: var(--sea); }
+.stat--yaz .stat__num      { color: var(--yaz); }
+.stat--mountain .stat__num { color: var(--mountain); }
+
+/* Doors — the big tappable entries. Deliberately unequal. */
+.doors {
+    display: grid;
+    gap: 2px;
+    background: var(--ink);
+    border: var(--rule);
+}
+
+@media (min-width: 768px) {
+    .doors { grid-template-columns: 1.4fr minmax(0, 1fr) minmax(0, 1fr); }
+}
+
+.door {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: 2.5rem;
+    min-height: 260px;
+    padding: clamp(1.35rem, 1rem + 1.6vw, 2.25rem);
+    text-decoration: none;
+    transition: transform 0.15s ease;
+}
+
+.door:hover { transform: scale(0.985); }
+
+.door--sea      { background: var(--sea); color: var(--on-colour); }
+.door--sand     { background: var(--sand); color: var(--ink); }
+.door--mountain { background: var(--mountain); color: var(--on-colour); }
+
+.door__title {
+    display: block;
+    font-family: var(--font-display);
+    font-weight: 800;
+    font-size: clamp(1.7rem, 1.2rem + 2.2vw, 2.6rem);
+    line-height: 0.98;
+    letter-spacing: -0.04em;
+    margin: 0.4rem 0 0.6rem;
+}
+
+.door__text {
+    display: block;
+    font-size: var(--t-sm);
+    line-height: 1.5;
+    margin: 0;
+    max-width: 32ch;
+}
+
+.door__go {
+    font-family: var(--font-mono);
+    font-size: var(--t-xs);
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+}
+
+/* --------------------------------------------------------------------------
+   9. Hero
+   -------------------------------------------------------------------------- */
+
+.hero {
+    background: var(--paper);
+    padding-block: clamp(2.5rem, 1.5rem + 5vw, 5.5rem);
+}
+
+.hero__grid {
+    display: grid;
+    gap: var(--gap);
+    align-items: end;
+}
+
+@media (min-width: 1024px) {
+    .hero__grid { grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr); }
+}
+
+.hero__title {
+    font-size: var(--t-h1);
+    margin: 0 0 1rem;
+}
+
+.hero__title em {
+    font-style: normal;
+    color: var(--yaz);
+}
+
+.hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1.75rem;
+}
+
+/* --------------------------------------------------------------------------
+   10. Figures — authored SVG only, never a photograph
+   -------------------------------------------------------------------------- */
+
+.figure {
+    margin: 0 0 var(--gap);
+}
+
+.figure__frame {
+    border: var(--rule);
+    background: var(--paper);
+    padding: clamp(0.9rem, 0.7rem + 1vw, 1.5rem);
+    overflow-x: auto;
+}
+
+.figure svg {
+    display: block;
+    width: 100%;
+    min-width: 540px;
+    height: auto;
+}
+
+.figure__caption {
+    margin-top: 0.85rem;
+    font-size: var(--t-sm);
+    line-height: 1.5;
+    color: var(--ink-quiet);
+    max-width: 62ch;
+}
+
+.figure__caption b { color: var(--ink); }
+
+/* Diagram legend — colour is never the only cue, so every swatch is labelled. */
+.legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem 1.25rem;
+    margin: 0 0 1rem;
+    padding: 0;
+    list-style: none;
+    font-family: var(--font-mono);
+    font-size: var(--t-xs);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.legend li {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+}
+
+.legend__dot {
+    width: 12px;
+    height: 12px;
+    border-radius: var(--radius-dot);
+    flex: none;
+}
+
+/* --------------------------------------------------------------------------
+   11. Notes, sourcing, page furniture
+   -------------------------------------------------------------------------- */
+
+.note {
+    border-left: 8px solid var(--sand);
+    background: var(--paper-sunk);
+    padding: clamp(1.1rem, 0.9rem + 1vw, 1.6rem);
+}
+
+.note h2,
+.note h3 { margin-top: 0; }
+
+.note > :last-child { margin-bottom: 0; }
+
+.sourcing-note {
+    font-size: var(--t-sm);
+    color: var(--ink-quiet);
+    border-top: var(--rule);
+    padding-top: 1rem;
+}
+
+.page-title { margin-bottom: 0.75rem; }
+
+.page-updated {
+    font-family: var(--font-mono);
+    font-size: var(--t-xs);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-quiet);
+}
+
+/* Section nav on content pages — static, no injected TOC. */
+.section-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px;
+    margin: 0 0 var(--gap);
+    padding: 0;
+    list-style: none;
+}
+
+.section-nav a {
+    display: flex;
+    align-items: center;
+    min-height: 48px;
+    padding: 0.6rem 1rem;
+    background: var(--paper-sunk);
+    color: var(--ink);
+    text-decoration: none;
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: var(--t-sm);
+}
+
+.section-nav a:hover {
+    background: var(--ink);
+    color: var(--paper);
+}
+
+.section-marker {
+    font-family: var(--font-tifinagh);
+    color: var(--yaz);
+    font-size: 1.5rem;
+    line-height: 1;
+    display: block;
+    margin-bottom: 0.6rem;
+}
+
+/* Two-column split used by the lineage page. */
+.split {
+    display: grid;
+    gap: 2px;
+    background: var(--ink);
+    border: var(--rule);
+}
+
+@media (min-width: 768px) {
+    .split { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+.split > * { margin: 0; }
+
+/* Scenario comparison table. */
+.scenarios {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--t-sm);
+}
+
+.scenarios th,
+.scenarios td {
+    text-align: left;
+    padding: 0.8rem 0.9rem;
+    border-bottom: 1px solid rgba(22, 19, 15, 0.15);
+    vertical-align: top;
+}
+
+.scenarios th {
+    font-family: var(--font-display);
+    font-weight: 800;
+    letter-spacing: -0.01em;
+}
+
+.scenarios thead th {
+    background: var(--ink);
+    color: var(--on-colour);
+    font-size: var(--t-xs);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-family: var(--font-mono);
+    font-weight: 600;
+}
+
+.verdict {
+    display: inline-block;
+    padding: 0.15rem 0.5rem;
+    font-family: var(--font-mono);
+    font-size: var(--t-xs);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
+.verdict--yes { background: var(--mountain); color: var(--on-colour); }
+.verdict--no  { background: var(--paper-sunk); color: var(--ink); }
+
+.table-scroll { overflow-x: auto; }
+
+/* --------------------------------------------------------------------------
+   12. Utilities
+   -------------------------------------------------------------------------- */
+
+.stack > * + * { margin-top: var(--gap); }
+.mt-0 { margin-top: 0; }
+.mb-0 { margin-bottom: 0; }
+
+/* --------------------------------------------------------------------------
+   13. Accessibility
+   -------------------------------------------------------------------------- */
+
+/* Visually hidden until keyboard focus. No offset to be out-run — see the
+   regression this replaced (#75). */
+.skip-to-main,
+.skip-link {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+}
+
+.skip-to-main:focus,
+.skip-link:focus {
+    top: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    width: auto;
+    height: auto;
+    overflow: visible;
+    clip: auto;
+    clip-path: none;
+    padding: 1rem;
+    background: var(--ink);
+    color: var(--paper);
+    text-decoration: none;
+    z-index: 1000;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+    outline: 3px solid var(--sea);
+    outline-offset: 2px;
+}
+
+/* On colour grounds the ring switches to paper so it stays visible. */
+.band--sea a:focus-visible,
+.band--mountain a:focus-visible,
+.band--yaz a:focus-visible,
+.band--ink a:focus-visible,
+.nav a:focus-visible,
+.site-footer a:focus-visible,
+.door:focus-visible {
+    outline-color: var(--paper);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html { scroll-behavior: auto; }
+
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+}
+
+/* --------------------------------------------------------------------------
+   14. Diagram type — inline SVG inherits these, which is why diagrams are
+   never <img src="*.svg">
+   -------------------------------------------------------------------------- */
+
+.dg-title {
+    font-family: var(--font-display);
+    font-weight: 800;
+    letter-spacing: -0.02em;
+}
+
+.dg-label {
+    font-family: var(--font-display);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+}
+
+.dg-meta {
+    font-family: var(--font-mono);
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+}
+
+.dg-body { font-family: var(--font-body); }

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
     <meta property="og:image:type" content="image/jpeg">
     <meta property="og:image:alt" content="E-M81 Berber marker distribution across North Africa">
     <meta property="og:locale" content="en_US">
+    <meta property="og:locale:alternate" content="ar_MA">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
@@ -35,10 +36,16 @@
     <meta name="twitter:description" content="Two DNA lines, one Amazigh family from Souss-Massa. One African and unbroken, one that crossed from Iberia before farming reached Morocco.">
     <meta name="twitter:image" content="https://northafricanorigins.com/img/og-card.jpg">
     <meta name="twitter:image:alt" content="Amazigh genetic heritage — E-M81 distribution map">
+    <meta name="twitter:creator" content="@AmazighHeritage">
+    <meta name="twitter:site" content="@AmazighHeritage">
+
+    <!-- LinkedIn -->
+    <meta name="linkedin:owner" content="North African Amazigh Heritage Project">
 
     <!-- Canonical URL -->
     <link rel="canonical" href="https://northafricanorigins.com/">
     <link rel="alternate" hreflang="en" href="https://northafricanorigins.com/">
+    <link rel="alternate" hreflang="ar" href="https://northafricanorigins.com/">
     <link rel="alternate" hreflang="x-default" href="https://northafricanorigins.com/">
 
     <!-- Favicon and App Icons -->

--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    
+
     <!-- SEO Meta Tags -->
-    <title>North African Amazigh DNA Heritage | E-PF2546 & H1 Research</title>
-    <meta name="description" content="Genetic analysis of Amazigh Chtouka lineage: E-PF2546 Y-DNA (~300 BCE) and H1 mtDNA (~11,400 years) from Souss-Massa, Morocco. Research-backed heritage.">
-    <meta name="keywords" content="Amazigh DNA, Berber genetics, Chtouka tribe, Souss-Massa heritage, E-PF2546, H1 haplogroup, Morocco genealogy, North African ancestry, Tachelhit culture, Argan ecosystem">
+    <title>North African Origins | Amazigh DNA from Souss-Massa</title>
+    <meta name="description" content="Two DNA lines, one Amazigh family from Souss-Massa, Morocco. E-PF2546 rooted in Africa, H1-T16189C! arrived from Iberia. What the evidence actually shows.">
+    <meta name="keywords" content="Amazigh DNA, Berber genetics, Chtouka tribe, Souss-Massa heritage, E-PF2546, H1 haplogroup, Morocco genealogy, North African ancestry, Tachelhit culture">
     <meta name="author" content="North African Amazigh Heritage Project">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
     <meta name="language" content="English">
@@ -15,243 +15,275 @@
     <meta name="geo.placename" content="Souss-Massa, Morocco">
     <meta name="geo.position" content="30.3333;-9.2333">
     <meta name="ICBM" content="30.3333, -9.2333">
-    
+
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:site_name" content="North African Amazigh Heritage">
-    <meta property="og:title" content="Amazigh DNA Heritage | E-PF2546 & H1 Research">
-    <meta property="og:description" content="Genetic analysis of Amazigh Chtouka lineage: E-PF2546 Y-DNA (~300 BCE) and H1 mtDNA (~11,400 years) from Souss-Massa, Morocco. Research-backed heritage.">
+    <meta property="og:site_name" content="North African Origins">
+    <meta property="og:title" content="North African Origins | Amazigh DNA from Souss-Massa">
+    <meta property="og:description" content="Two DNA lines, one Amazigh family from Souss-Massa, Morocco. E-PF2546 rooted in Africa, H1-T16189C! arrived from Iberia. What the evidence actually shows.">
     <meta property="og:url" content="https://northafricanorigins.com/">
     <meta property="og:image" content="https://northafricanorigins.com/img/og-card.jpg">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:image:alt" content="E-M81 Berber Marker Distribution Across North Africa - Amazigh Genetic Heritage Map">
+    <meta property="og:image:type" content="image/jpeg">
+    <meta property="og:image:alt" content="E-M81 Berber marker distribution across North Africa">
     <meta property="og:locale" content="en_US">
-    <meta property="og:locale:alternate" content="ar_MA">
-    
+
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Amazigh DNA Heritage | E-PF2546 & H1 Research">
-    <meta name="twitter:description" content="Comprehensive genetic and historical analysis of Amazigh Chtouka lineage from Souss-Massa, Morocco. Explore ancient E-PF2546 and H1 lineages.">
+    <meta name="twitter:title" content="North African Origins | Amazigh DNA from Souss-Massa">
+    <meta name="twitter:description" content="Two DNA lines, one Amazigh family from Souss-Massa. One African and unbroken, one that crossed from Iberia before farming reached Morocco.">
     <meta name="twitter:image" content="https://northafricanorigins.com/img/og-card.jpg">
-    <meta name="twitter:image:alt" content="Amazigh Genetic Heritage - E-M81 Distribution Map">
-    <meta name="twitter:creator" content="@AmazighHeritage">
-    <meta name="twitter:site" content="@AmazighHeritage">
-    
-    <!-- LinkedIn -->
-    <meta property="og:image:type" content="image/jpeg">
-    <meta name="linkedin:owner" content="North African Amazigh Heritage Project">
-    
+    <meta name="twitter:image:alt" content="Amazigh genetic heritage — E-M81 distribution map">
+
     <!-- Canonical URL -->
     <link rel="canonical" href="https://northafricanorigins.com/">
-    
-    <!-- Alternate Languages -->
     <link rel="alternate" hreflang="en" href="https://northafricanorigins.com/">
-    <link rel="alternate" hreflang="ar" href="https://northafricanorigins.com/">
     <link rel="alternate" hreflang="x-default" href="https://northafricanorigins.com/">
-    
+
     <!-- Favicon and App Icons -->
     <link rel="icon" type="image/png" href="/favicon-32x32.png">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
-    <meta name="theme-color" content="#3E2723">
-    <meta name="msapplication-TileColor" content="#3E2723">
-    
-    <!-- Preconnect for Performance -->
+    <meta name="theme-color" content="#1746C4">
+    <meta name="msapplication-TileColor" content="#1746C4">
+
+    <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="preconnect" href="https://cdn.jsdelivr.net">
-    
-    <!-- LCP hero: discovered early, never lazy (issue #39) -->
-    <link rel="preload" as="image" href="img/hero-dna-morocco.webp" fetchpriority="high">
+    <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400..800&family=IBM+Plex+Mono:wght@400;600&family=Instrument+Sans:wght@400..700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Tifinagh&text=%E2%B5%A3&display=swap" rel="stylesheet">
 
-    <!-- CSS and Scripts -->
-    <!-- Typography: Literata for long-form reading, Archivo for headings and
-         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
-         @import-ed from the stylesheet, which was render-blocking. -->
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
-    <link rel="stylesheet" href="css/styles.css">
-    <script src="js/reading-aids.js" defer></script>
-    
-    <!-- Structured Data - JSON-LD -->
+    <link rel="stylesheet" href="css/main.css">
+
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "WebSite",
-      "name": "North African Amazigh Heritage",
-      "description": "Comprehensive genetic and historical analysis of Amazigh Chtouka lineage from Souss-Massa, Morocco",
+      "name": "North African Origins",
+      "alternateName": "North African Amazigh Heritage",
       "url": "https://northafricanorigins.com/",
-      "author": {
-        "@type": "Organization",
-        "name": "North African Amazigh Heritage Project"
-      },
-      "about": {
-        "@type": "Thing",
-        "name": "Amazigh Heritage Research",
-        "description": "Multi-disciplinary analysis combining genetics, history, and anthropology of North African Berber lineages"
-      },
-      "mainEntity": {
-        "@type": "ResearchProject",
-        "name": "Chtouka Lineage Analysis",
-        "description": "Genetic analysis of E-PF2546 Y-DNA and H1 mtDNA haplogroups in Souss-Massa region",
-        "location": {
-          "@type": "Place",
-          "name": "Souss-Massa",
-          "addressCountry": "MA",
-          "geo": {
-            "@type": "GeoCoordinates",
-            "latitude": 30.3333,
-            "longitude": -9.2333
-          }
-        }
-      },
-      "keywords": ["Amazigh genetics", "Berber DNA", "North African ancestry", "Souss-Massa heritage", "Chtouka tribe"],
-      "inLanguage": "en"
-    }
-    </script>
-    
-    <!-- FAQ Schema for AI Search Engines -->
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "FAQPage",
-      "mainEntity": [
-        {
-          "@type": "Question",
-          "name": "What is the E-PF2546 haplogroup?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "E-PF2546 is a Y-DNA haplogroup subclade of E-M81, the 'Berber marker' that defines indigenous North African Amazigh populations. E-PF2546 formed approximately 2,300 years ago (~300 BCE) per the YFull YTree database, during the Iron Age. Its parent clade E-M81 underwent a rapid demographic expansion with a TMRCA debated between ~2,000-4,200 years ago (D'Atanasio et al. 2018)."
-          }
-        },
-        {
-          "@type": "Question",
-          "name": "How did H1 mtDNA arrive in North Africa?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "H1 mtDNA arrived in North Africa approximately 11,400 years ago (range: ~9,000-13,700 ya) during the Early Holocene, as estimated by Ottoni et al. (2010, PLOS ONE). Women carrying H1 migrated from the Franco-Cantabrian refuge (Iberia) across the Strait of Gibraltar, integrating with local Amazigh populations through female-mediated gene flow. This has been confirmed by Villalba-Mouco et al. (2023, Nature) via ancient DNA from Neolithic Morocco."
-          }
-        },
-        {
-          "@type": "Question",
-          "name": "What is the Chtouka confederation?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "The Chtouka (Aït Chtouk) is a major tribal confederation of Tachelhit-speaking Amazigh people in the Souss-Massa region of Morocco. They are sedentary agriculturalists and pastoralists known for their traditional agadir granaries, argan oil production, and preservation of Tachelhit language and customs."
-          }
-        },
-        {
-          "@type": "Question",
-          "name": "Where is the Souss-Massa region?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Souss-Massa is a fertile region in southwestern Morocco, nestled between the High Atlas Mountains and the Atlantic Ocean. It includes the Chtouka-Aït Baha Province and has been the heartland of Amazigh civilization for millennia, serving as the birthplace of the Almoravid and Almohad Berber dynasties."
-          }
-        },
-        {
-          "@type": "Question",
-          "name": "What is the difference between Amazigh and Berber?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Amazigh and Berber refer to the same indigenous North African people. 'Amazigh' (meaning 'free people') is the preferred self-designation, while 'Berber' is the historical exonym derived from Greek/Latin. Both terms are used interchangeably in academic and genetic research contexts."
-          }
-        }
-      ]
+      "description": "Two DNA lines, one Amazigh family from Souss-Massa, Morocco. E-PF2546 rooted in Africa, H1-T16189C! arrived from Iberia.",
+      "inLanguage": "en",
+      "dateModified": "2026-09-07"
     }
     </script>
 </head>
 <body>
-    <!-- Skip to main content for accessibility -->
     <a href="#main-content" class="skip-to-main">Skip to main content</a>
-    
-    <header role="banner">
-        <div class="header-content">
-            <a class="site-brand" href="index.html">
-                <span class="site-brand-mark" aria-hidden="true"></span>
-                <span class="site-brand-name">North African Amazigh Heritage</span>
+
+    <header class="site-header" role="banner">
+        <div class="container site-header__inner">
+            <a class="brand" href="index.html">
+                <span class="brand__mark" aria-hidden="true">ⵣ</span>
+                <span>North African Origins</span>
             </a>
         </div>
     </header>
-    <nav class="main-nav">
-        <div class="nav-container">
-            <a href="index.html" class="active">Home</a>
-            <a href="lineage.html">Lineage History</a>
-            <a href="genetics.html">Genetics</a>
-            <a href="culture.html">Culture</a>
-            <a href="research.html">Research</a>
-            <a href="contact.html">Contact</a>
+
+    <nav class="nav" aria-label="Primary">
+        <div class="container">
+            <ul class="nav__list">
+                <li><a class="nav__link" href="index.html" aria-current="page">Home</a></li>
+                <li><a class="nav__link" href="lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="genetics.html">DNA</a></li>
+                <li><a class="nav__link" href="culture.html">Culture</a></li>
+                <li><a class="nav__link" href="research.html">Research</a></li>
+                <li><a class="nav__link" href="contact.html">Contact</a></li>
+            </ul>
         </div>
     </nav>
 
-    <main id="main-content" class="container" role="main" data-reading-aids="off">
-        <!-- Introduction Section -->
-        <section class="card home-hero-card" itemscope itemtype="https://schema.org/ScholarlyArticle">
-            <div class="home-hero-grid">
-                <div class="home-hero-content">
-                    <div class="home-hero-kicker-row">
-                        <span class="home-hero-kicker">Genetic Research</span>
-                        <div class="home-hero-kicker-line"></div>
+    <main id="main-content">
+
+        <!-- Hero -->
+        <section class="hero">
+            <div class="container">
+                <div class="hero__grid">
+                    <div>
+                        <span class="kicker">Souss-Massa, Morocco</span>
+                        <h1 class="hero__title">Who were we, <em>really</em>?</h1>
+                        <div class="hero__actions">
+                            <a class="btn" href="lineage.html">Trace the two lines</a>
+                            <a class="btn btn--ghost" href="start-here.html">New here? Start here</a>
+                        </div>
                     </div>
-                    <h1 itemprop="headline" class="home-hero-title">Ancient Amazigh Lineage — <span class="home-hero-accent">A Genetic Analysis</span></h1>
-                    <p class="text-large home-hero-copy">A comprehensive multi-disciplinary study examining the convergence of indigenous North African (E-PF2546) and European (H1-T16189C!) lineages within the Chtouka confederation of the Souss-Massa region.</p>
-                    <div class="home-hero-actions">
-                        <a href="lineage.html" class="btn btn-copper">Read the analysis</a>
-                        <a href="start-here.html" class="hero-secondary-link">New here? Start with the overview</a>
+                    <p class="lead">One Amazigh (Berber) family from the Souss valley carries two ancestries that could hardly be more different. One never left Africa. The other crossed the sea from Iberia before farming reached Morocco.</p>
+                </div>
+            </div>
+        </section>
+
+        <hr class="stripe stripe--tall">
+
+        <!-- The two lines -->
+        <section class="band band--sunk" aria-labelledby="two-lines">
+            <div class="container">
+                <span class="kicker">The short version</span>
+                <h2 id="two-lines">Two lines that met in one valley</h2>
+
+                <figure class="figure">
+                    <ul class="legend">
+                        <li><span class="legend__dot" style="background: var(--sea)"></span> Father's line — solid</li>
+                        <li><span class="legend__dot" style="background: var(--yaz)"></span> Mother's line — dashed</li>
+                    </ul>
+                    <div class="figure__frame">
+                        <svg viewBox="0 0 900 400" role="img" aria-labelledby="dg1-title dg1-desc" class="dg">
+                            <title id="dg1-title">Two ancestral lines converging on Souss-Massa</title>
+                            <desc id="dg1-desc">The paternal line E-PF2546 descends within Africa for more than 65,000 years. The maternal line H1-T16189C! crosses from Iberia into North Africa between 8,000 and 11,000 years ago. Both meet in present-day Souss-Massa, Morocco.</desc>
+
+                            <!-- Origin blocks -->
+                            <rect x="20" y="20" width="330" height="56" fill="var(--sea)"></rect>
+                            <text class="dg-label" x="40" y="57" fill="var(--on-colour)" font-size="27">AFRICA</text>
+
+                            <rect x="550" y="20" width="330" height="56" fill="var(--yaz)"></rect>
+                            <text class="dg-label" x="570" y="57" fill="var(--on-colour)" font-size="27">EUROPE — IBERIA</text>
+
+                            <!-- Descent lines: solid vs dashed, so colour is not the only cue -->
+                            <path d="M110 76 V262" stroke="var(--sea)" stroke-width="11" fill="none"></path>
+                            <path d="M790 76 V262" stroke="var(--yaz)" stroke-width="11" fill="none" stroke-dasharray="20 14"></path>
+
+                            <!-- Father's line labels -->
+                            <text class="dg-label" x="140" y="130" fill="var(--ink)" font-size="25">Father to son,</text>
+                            <text class="dg-label" x="140" y="160" fill="var(--ink)" font-size="25">never leaving Africa</text>
+                            <text class="dg-meta" x="140" y="200" fill="var(--sea)" font-size="20">E-PF2546</text>
+                            <text class="dg-body" x="140" y="234" fill="var(--ink-quiet)" font-size="19">65,000+ years of African descent</text>
+
+                            <!-- Mother's line labels -->
+                            <text class="dg-label" x="760" y="130" fill="var(--ink)" font-size="25" text-anchor="end">Mother to daughter,</text>
+                            <text class="dg-label" x="760" y="160" fill="var(--ink)" font-size="25" text-anchor="end">across the Strait</text>
+                            <text class="dg-meta" x="760" y="200" fill="var(--yaz)" font-size="20" text-anchor="end">H1-T16189C!</text>
+                            <text class="dg-body" x="760" y="234" fill="var(--ink-quiet)" font-size="19" text-anchor="end">arrived 8,000–11,000 years ago</text>
+
+                            <!-- Convergence -->
+                            <path d="M110 262 V300 H450" stroke="var(--sea)" stroke-width="11" fill="none"></path>
+                            <path d="M790 262 V300 H450" stroke="var(--yaz)" stroke-width="11" fill="none" stroke-dasharray="20 14"></path>
+                            <path d="M450 300 V326" stroke="var(--ink)" stroke-width="11" fill="none"></path>
+
+                            <!-- Meeting point -->
+                            <rect x="235" y="326" width="430" height="62" fill="var(--mountain)"></rect>
+                            <text class="dg-label" x="450" y="353" fill="var(--on-colour)" font-size="24" text-anchor="middle">SOUSS-MASSA, MOROCCO</text>
+                            <text class="dg-body" x="450" y="376" fill="var(--on-colour)" font-size="18" text-anchor="middle">Aït Moussa, of the Chtouka confederation</text>
+                        </svg>
+                    </div>
+                    <figcaption class="figure__caption"><b>Two lines, two completely different pasts.</b> The paternal line is autochthonous to North Africa. The maternal line is a European lineage that became North African thousands of years before anything was written down. Both are equally ancestral.</figcaption>
+                </figure>
+            </div>
+        </section>
+
+        <!-- Numbers -->
+        <section class="band band--tight" aria-labelledby="numbers">
+            <div class="container">
+                <h2 id="numbers" class="mt-0">The numbers that matter</h2>
+                <div class="stat-row">
+                    <div class="stat stat--sea">
+                        <span class="stat__num">65,000+</span>
+                        <span class="stat__label">Years African, father to son</span>
+                    </div>
+                    <div class="stat stat--sea">
+                        <span class="stat__num">~400 BCE</span>
+                        <span class="stat__label">Origin of branch <span class="hg">E-PF2546</span></span>
+                    </div>
+                    <div class="stat stat--yaz">
+                        <span class="stat__num">8–11k</span>
+                        <span class="stat__label">Years since <span class="hg">H1</span> crossed from Iberia</span>
+                    </div>
+                    <div class="stat stat--mountain">
+                        <span class="stat__num">12</span>
+                        <span class="stat__label">Peer-reviewed papers summarised</span>
                     </div>
                 </div>
-                <div class="home-hero-media">
-                    <img src="img/hero-dna-morocco.webp" alt="DNA helix visualization showing genetic heritage analysis of Amazigh Chtouka lineage from Souss-Massa, Morocco" width="800" height="300" class="home-hero-image" fetchpriority="high" decoding="async">
-                    <div class="home-hero-meta">
-                        <div class="home-hero-meta-title">Study Timeline</div>
-                        <div class="home-hero-meta-copy">Research Period: 2023-2026 | 11,000+ Years Heritage Span</div>
+                <p class="figure__caption">Every figure here is an estimate with a published range, not a fixed date. The ranges are given in full on <a href="lineage.html">the two lines</a>.</p>
+            </div>
+        </section>
+
+        <!-- Doors -->
+        <section class="band band--sunk band--tight" aria-labelledby="doors">
+            <div class="container">
+                <h2 id="doors" class="mt-0">Three ways in</h2>
+                <div class="doors">
+                    <a class="door door--sea" href="genetics.html">
+                        <span class="door__go">01</span>
+                        <span>
+                            <span class="door__title">DNA</span>
+                            <span class="door__text">What a haplogroup actually is, how the dates are calculated, and why a Y-chromosome and a mitochondrion tell you different halves of a story.</span>
+                        </span>
+                    </a>
+                    <a class="door door--sand" href="maps-sites.html">
+                        <span class="door__go">02</span>
+                        <span>
+                            <span class="door__title">Land</span>
+                            <span class="door__text">The Souss plain, the Anti-Atlas, and the valley of Aït Moussa — the ground this family has farmed and herded for centuries.</span>
+                        </span>
+                    </a>
+                    <a class="door door--mountain" href="culture.html">
+                        <span class="door__go">03</span>
+                        <span>
+                            <span class="door__title">Language</span>
+                            <span class="door__text">Tachelhit, still the most spoken Amazigh language in Morocco, with a written literature going back to the 16th century.</span>
+                        </span>
+                    </a>
+                </div>
+            </div>
+        </section>
+
+        <!-- Honesty note -->
+        <section class="band band--ink band--tight" aria-labelledby="honest">
+            <div class="container">
+                <div class="hero__grid">
+                    <div>
+                        <span class="kicker">Read this before you believe any of it</span>
+                        <h2 id="honest" class="mt-0">Two lines out of a thousand</h2>
+                    </div>
+                    <div class="prose">
+                        <p>A Y-chromosome and a mitochondrion are two threads out of the many thousands that make up an ancestry. They are not an ethnicity, they are not a nationality, and they cannot tell you what anyone looked like or believed.</p>
+                        <p><a href="limitations.html">What this evidence cannot show</a></p>
                     </div>
                 </div>
             </div>
         </section>
 
-        <!-- Section Navigation Cards -->
-        <section class="home-section-grid" aria-label="Explore the site">
-            <article class="card home-section-card home-section-lead">
-                <div class="home-section-kicker">Genetics &amp; DNA</div>
-                <h2 class="home-section-title"><a href="lineage.html">Lineage History</a></h2>
-                <p class="home-section-copy">E-PF2546 paternal and H1-T16189C! maternal haplogroups — 11,000+ years of ancestry traced through multi-disciplinary analysis of the Chtouka confederation.</p>
-                <a href="lineage.html" class="btn btn-copper home-section-cta">Read the Analysis</a>
-            </article>
-            <article class="card home-section-card">
-                <div class="home-section-kicker">Science</div>
-                <h2 class="home-section-title"><a href="genetics.html">The DNA Revolution</a></h2>
-                <p class="home-section-copy">How ancient DNA and modern genomics are rewriting the story of North African prehistory and human migration across the Maghreb.</p>
-                <a href="genetics.html" class="btn btn-outline btn-outline-copper home-section-cta">Explore Genetics</a>
-            </article>
-            <article class="card home-section-card">
-                <div class="home-section-kicker">Heritage</div>
-                <h2 class="home-section-title"><a href="culture.html">Cultural Heritage</a></h2>
-                <p class="home-section-copy">Tachelhit language, Agadir granaries, Argan oil traditions — the living culture of the Chtouka confederation in the Souss-Massa valley.</p>
-                <a href="culture.html" class="btn btn-outline btn-outline-copper home-section-cta">Explore Culture</a>
-            </article>
-            <article class="card home-section-card">
-                <div class="home-section-kicker">Papers</div>
-                <h2 class="home-section-title"><a href="research.html">Research &amp; Sources</a></h2>
-                <p class="home-section-copy">Peer-reviewed papers, ancient DNA studies, and academic sources that underpin every claim on this site.</p>
-                <a href="research.html" class="btn btn-outline btn-outline-copper home-section-cta">Browse Research</a>
-            </article>
+        <section class="band band--tight">
+            <div class="container">
+                <p class="page-updated">Last updated: 7 September 2026</p>
+            </div>
         </section>
-        <p class="page-updated page-updated-footer">Last updated: 6 September 2026</p>
+
     </main>
 
-    <footer role="contentinfo">
-        <p>&copy; 2026 North African Amazigh Heritage Project | Preserving Chtouka heritage of the Souss-Massa</p>
-        <nav class="footer-nav" aria-label="Secondary navigation">
-            <a href="start-here.html">Start Here</a>
-            <a href="glossary.html">Glossary</a>
-            <a href="limitations.html">Limitations</a>
-            <a href="maps-sites.html">Maps &amp; Sites</a>
-            <a href="contact.html">Contact</a>
-        </nav>
+    <hr class="stripe">
+
+    <footer class="site-footer" role="contentinfo">
+        <div class="container">
+            <div class="site-footer__grid">
+                <div>
+                    <h2>The research</h2>
+                    <ul>
+                        <li><a href="lineage.html">The two lines</a></li>
+                        <li><a href="genetics.html">DNA and haplogroups</a></li>
+                        <li><a href="research.html">Papers and sources</a></li>
+                        <li><a href="limitations.html">What this cannot show</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h2>Place and people</h2>
+                    <ul>
+                        <li><a href="culture.html">Culture and language</a></li>
+                        <li><a href="maps-sites.html">Maps and sites</a></li>
+                        <li><a href="glossary.html">Glossary</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h2>About</h2>
+                    <ul>
+                        <li><a href="start-here.html">Start here</a></li>
+                        <li><a href="contact.html">Contact</a></li>
+                    </ul>
+                </div>
+            </div>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+        </div>
     </footer>
-
-
 </body>
 </html>

--- a/lineage.html
+++ b/lineage.html
@@ -3,709 +3,398 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    
-    <!-- SEO Meta Tags -->
-    <title>Amazigh Lineage | E-PF2546 & H1 DNA Research</title>
-    <meta name="description" content="Genetic analysis of Amazigh Chtouka: E-PF2546 Y-DNA (~300 BCE) and H1-T16189C mtDNA (~11,400 years). Souss-Massa history, Tachelhit culture, and prehistoric migrations.">
-    <meta name="keywords" content="E-PF2546 haplogroup, H1-T16189C mtDNA, Amazigh genetics research, Berber DNA analysis, Chtouka tribe history, Souss-Massa genealogy, North African ancestry, European migration, Iron Age Morocco, Neolithic genetics, Tachelhit language, Argan culture">
+
+    <title>The two lines | E-PF2546 and H1-T16189C!</title>
+    <meta name="description" content="One Amazigh family, two ancestries: E-PF2546 rooted in Africa for 65,000 years, and H1-T16189C! which crossed from Iberia 8,000-11,000 years ago.">
+    <meta name="keywords" content="E-PF2546, H1-T16189C!, E-M81, Amazigh lineage, Chtouka, Souss-Massa, asymmetrical admixture, Berber Y-DNA, North African mtDNA">
     <meta name="author" content="North African Amazigh Heritage Project">
-    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
-    <meta name="language" content="English">
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
     <meta name="geo.region" content="MA-09">
-    <meta name="geo.placename" content="Chtouka-Aït Baha, Souss-Massa, Morocco">
-    
-    <!-- Article-specific Meta -->
-    <meta name="article:published_time" content="2025-10-26T00:00:00Z">
-    <meta name="article:modified_time" content="2026-02-13T00:00:00Z">
-    <meta name="article:section" content="Genetic Research">
-    <meta name="article:tag" content="Amazigh genetics, Berber DNA, North African ancestry, Genetic genealogy, Haplogroup analysis">
-    
-    <!-- Open Graph / Facebook -->
+    <meta name="geo.placename" content="Souss-Massa, Morocco">
+
     <meta property="og:type" content="article">
-    <meta property="og:site_name" content="North African Amazigh Heritage">
-    <meta property="og:title" content="Amazigh Lineage | E-PF2546 & H1 DNA Research">
-    <meta property="og:description" content="Genetic analysis of Amazigh Chtouka: E-PF2546 Y-DNA (~300 BCE) and H1-T16189C mtDNA (~11,400 years). Souss-Massa history and prehistoric migrations.">
+    <meta property="og:site_name" content="North African Origins">
+    <meta property="og:title" content="The two lines | E-PF2546 and H1-T16189C!">
+    <meta property="og:description" content="One Amazigh family, two ancestries: E-PF2546 rooted in Africa for 65,000 years, and H1-T16189C! which crossed from Iberia 8,000-11,000 years ago.">
     <meta property="og:url" content="https://northafricanorigins.com/lineage.html">
     <meta property="og:image" content="https://northafricanorigins.com/img/og-card.jpg">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:image:alt" content="E-PF2546 Haplogroup Distribution Chart - Amazigh Genetic Research">
-    <meta property="article:author" content="North African Amazigh Heritage Project">
-    
-    <!-- Twitter Card -->
+    <meta property="og:image:type" content="image/jpeg">
+    <meta property="og:image:alt" content="E-M81 Berber marker distribution across North Africa">
+
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Amazigh Lineage | E-PF2546 & H1 DNA Research">
-    <meta name="twitter:description" content="In-depth genetic analysis of Chtouka lineage: E-PF2546 (Iron Age) and H1 (Early Holocene) haplogroups spanning 11,400+ years of heritage.">
+    <meta name="twitter:title" content="The two lines | E-PF2546 and H1-T16189C!">
+    <meta name="twitter:description" content="One African father-line, one European mother-line, and the prehistoric migration that explains how they met.">
     <meta name="twitter:image" content="https://northafricanorigins.com/img/og-card.jpg">
-    <meta name="twitter:image:alt" content="E-PF2546 Haplogroup Distribution - Amazigh Genetic Analysis">
-    
-    <!-- Canonical URL -->
+    <meta name="twitter:image:alt" content="Amazigh genetic heritage — E-M81 distribution map">
+
     <link rel="canonical" href="https://northafricanorigins.com/lineage.html">
-    
-    <!-- Breadcrumb Navigation -->
-    <link rel="up" href="https://northafricanorigins.com/">
-    
-    <!-- Favicon and Performance -->
+
     <link rel="icon" type="image/png" href="/favicon-32x32.png">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
-    <meta name="theme-color" content="#3E2723">
-    <!-- Preconnect for Performance -->
+    <meta name="theme-color" content="#1746C4">
+
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="preconnect" href="https://cdn.jsdelivr.net">
-    
-    <!-- CSS and Scripts -->
-    <!-- Typography: Literata for long-form reading, Archivo for headings and
-         chrome, IBM Plex Mono for haplogroup notation. Linked here rather than
-         @import-ed from the stylesheet, which was render-blocking. -->
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
-    <link rel="stylesheet" href="css/styles.css">
-    <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
-    <script src="js/reading-aids.js" defer></script>
-    <script type="module">
-        import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
-        mermaid.initialize({ 
-            startOnLoad: true,
-            theme: 'base',
-            themeVariables: {
-                primaryColor: '#F4F0E8',
-                primaryTextColor: '#3E2723',
-                primaryBorderColor: '#CD7F32',
-                lineColor: '#8B4513',
-                secondaryColor: '#F8F2E7',
-                tertiaryColor: '#FAF8F4',
-                fontSize: '16px',
-                fontFamily: 'Inter, sans-serif'
-            }
-        });
-    </script>
-    
-    <!-- Structured Data - JSON-LD for Article -->
+    <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400..800&family=IBM+Plex+Mono:wght@400;600&family=Instrument+Sans:wght@400..700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Tifinagh&text=%E2%B5%A3&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="css/main.css">
+
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ScholarlyArticle",
-      "headline": "Complete Amazigh Lineage Analysis: E-PF2546 & H1 Genetic Research",
-      "description": "In-depth genetic analysis of Amazigh Chtouka lineage combining E-PF2546 paternal and H1-T16189C maternal haplogroups",
-      "author": {
-        "@type": "Organization",
-        "name": "North African Amazigh Heritage Project"
-      },
-      "datePublished": "2025-10-26",
-      "dateModified": "2026-09-06",
+      "@type": "Article",
+      "headline": "The two lines: E-PF2546 and H1-T16189C!",
+      "description": "One Amazigh family, two ancestries: E-PF2546 rooted in Africa, and H1-T16189C! which crossed from Iberia 8,000-11,000 years ago.",
+      "url": "https://northafricanorigins.com/lineage.html",
+      "inLanguage": "en",
+      "dateModified": "2026-09-07",
       "publisher": {
         "@type": "Organization",
-        "name": "North African Amazigh Heritage",
-        "logo": {
-          "@type": "ImageObject",
-          "url": "https://northafricanorigins.com/icon-512x512.png"
-        }
-      },
-      "mainEntityOfPage": {
-        "@type": "WebPage",
-        "@id": "https://northafricanorigins.com/lineage.html"
-      },
-      "about": [
-        {
-          "@type": "Thing",
-          "name": "E-PF2546 Haplogroup",
-          "description": "Y-DNA haplogroup characteristic of North African Amazigh populations, formed ~300 BCE (per YFull YTree)"
-        },
-        {
-          "@type": "Thing",
-          "name": "H1-T16189C Haplogroup", 
-          "description": "Mitochondrial DNA haplogroup of European origin, arrived in North Africa ~11,400 years ago (Ottoni et al. 2010)"
-        },
-        {
-          "@type": "Place",
-          "name": "Chtouka Confederation",
-          "description": "Traditional Amazigh tribal confederation in Souss-Massa region",
-          "geo": {
-            "@type": "GeoCoordinates",
-            "latitude": 30.3333,
-            "longitude": -9.2333
-          }
-        }
-      ],
-      "keywords": ["E-PF2546", "H1-T16189C", "Amazigh genetics", "Chtouka tribe", "Souss-Massa", "North African ancestry"],
-      "inLanguage": "en",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "North African Amazigh Heritage",
-        "url": "https://northafricanorigins.com/"
+        "name": "North African Origins"
       }
     }
     </script>
 </head>
 <body>
-    <!-- Skip to main content for accessibility -->
     <a href="#main-content" class="skip-to-main">Skip to main content</a>
-    
-    <header role="banner">
-        <div class="header-content">
-            <a class="site-brand" href="index.html">
-                <span class="site-brand-mark" aria-hidden="true"></span>
-                <span class="site-brand-name">North African Amazigh Heritage</span>
+
+    <header class="site-header" role="banner">
+        <div class="container site-header__inner">
+            <a class="brand" href="index.html">
+                <span class="brand__mark" aria-hidden="true">ⵣ</span>
+                <span>North African Origins</span>
             </a>
         </div>
     </header>
-    <nav class="main-nav">
-        <div class="nav-container">
-            <a href="index.html">Home</a>
-            <a href="lineage.html" class="active">Lineage History</a>
-            <a href="genetics.html">Genetics</a>
-            <a href="culture.html">Culture</a>
-            <a href="research.html">Research</a>
-            <a href="contact.html">Contact</a>
+
+    <nav class="nav" aria-label="Primary">
+        <div class="container">
+            <ul class="nav__list">
+                <li><a class="nav__link" href="index.html">Home</a></li>
+                <li><a class="nav__link" href="lineage.html" aria-current="page">The two lines</a></li>
+                <li><a class="nav__link" href="genetics.html">DNA</a></li>
+                <li><a class="nav__link" href="culture.html">Culture</a></li>
+                <li><a class="nav__link" href="research.html">Research</a></li>
+                <li><a class="nav__link" href="contact.html">Contact</a></li>
+            </ul>
         </div>
     </nav>
 
-    <!-- Breadcrumb Navigation -->
-    <nav aria-label="Breadcrumb" class="breadcrumb">
-        <ol itemscope itemtype="https://schema.org/BreadcrumbList">
-            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
-                <a itemprop="item" href="index.html">
-                    <span itemprop="name">Home</span>
-                </a>
-                <meta itemprop="position" content="1" />
-            </li>
-            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
-                <span itemprop="name">Complete Lineage Analysis</span>
-                <meta itemprop="position" content="2" />
-            </li>
-        </ol>
-    </nav>
+    <div class="container">
+        <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="index.html">Home</a> &rsaquo; The two lines
+        </nav>
+    </div>
 
-    <main id="main-content" class="container" role="main">
-        <h1 class="page-title">Complete Lineage Analysis</h1>
-        <p class="page-updated">Last updated: 6 September 2026</p>
-        <!-- Introduction -->
-        <section class="card">
-            <h2>Introduction: A Portrait of an Amazigh Lineage</h2>
-            
-            <div style="background: #FFFFFF; padding: 2rem; border-radius: 12px; margin: 2rem 0; box-shadow: 0 1px 3px rgba(0,0,0,0.08);">
-                <h3 style="text-align: center; color: var(--text-primary); margin-bottom: 1.5rem; font-size: 1.1rem; font-weight: 600;">Phylogenetic Heritage Overview</h3>
-                
-                <div class="mermaid" style="display: flex; justify-content: center;">
-%%{init: {'theme':'base', 'themeVariables': { 'fontSize':'14px', 'fontFamily':'Literata'}}}%%
-flowchart LR
-    A[("Common<br/>Ancestor")]
-    B["<b>Y-DNA: E-PF2546</b><br/>Paternal · African<br/><i>Indigenous North African,<br/>autochthonous to Amazigh</i>"]
-    C["<b>mtDNA: H1-T16189C!</b><br/>Maternal · European<br/><i>Western European marker<br/>from Ice Age refugia</i>"]
-    
-    A -->|"Paternal"| B
-    A -->|"Maternal"| C
-    
-    style A fill:#EDE6DA,stroke:#8B7355,stroke-width:2.5px,color:#3E2723
-    style B fill:#F7E8D5,stroke:#8B4513,stroke-width:3px,color:#3E2723,text-align:left
-    style C fill:#FDF7EF,stroke:#8B4513,stroke-width:3px,color:#3E2723,text-align:left,stroke-dasharray: 6 4
-    
-    linkStyle 0 stroke:#D4A629,stroke-width:2.5px
-    linkStyle 1 stroke:#8B4513,stroke-width:2.5px,stroke-dasharray: 6 4
-                </div>
-                
-                <div style="text-align: center; margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--border);">
-                    <div style="display: inline-block; background: var(--background-alt); padding: 0.75rem 1.25rem; border-radius: 8px;">
-                        <span style="font-size: 0.875rem; color: var(--text-secondary);">Convergence:</span>
-                        <span style="font-size: 0.95rem; font-weight: 700; color: var(--text-primary); margin-left: 0.5rem;">Chtouka Confederation, Souss-Massa</span>
-                    </div>
-                </div>
-            </div>
-            
-            <p class="text-large">
-                This report presents a comprehensive, multi-disciplinary analysis of a specific lineage rooted in the Souss-Massa region of Morocco. The synthesis of genetic data, historical records, and anthropological studies reveals a narrative that is both deeply personal and emblematic of the broader demographic history of North Africa.
-            </p>
-            
-            <p>
-                The core of this analysis lies in the convergence of two distinct ancestral streams: a paternal lineage belonging to Y-DNA haplogroup <strong>E-PF2546</strong>, which is autochthonous to North Africa and strongly associated with the indigenous <a href="culture.html">Amazigh (Berber)</a> people, and a maternal lineage belonging to mtDNA haplogroup <strong>H1-T16189C!</strong>, a classic Western European marker with ancient origins that arrived via <a href="genetics.html">prehistoric migrations</a>.
-            </p>
+    <main id="main-content">
 
-            <div class="grid">
-                <table class="data-table">
-                    <thead>
-                        <tr>
-                            <th>Category</th>
-                            <th>Data</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td><strong>Paternal Y-DNA</strong></td>
-                            <td>E-PF2546 (E-M96 > E-M81 > E-PF2546)</td>
-                        </tr>
-                        <tr>
-                            <td><strong>Maternal mtDNA</strong></td>
-                            <td>H1-T16189C! (HV > H > H1)</td>
-                        </tr>
-                        <tr>
-                            <td><strong>Autosomal DNA</strong></td>
-                            <td>100% Middle East & North Africa (Maghreb & Egypt)</td>
-                        </tr>
-                        <tr>
-                            <td><strong>Geographic Origin</strong></td>
-                            <td>Souss-Massa, Morocco</td>
-                        </tr>
-                        <tr>
-                            <td><strong>Tribal Confederation</strong></td>
-                            <td>Chtouka (Aït Chtouk)</td>
-                        </tr>
-                        <tr>
-                            <td><strong>Regional Territory</strong></td>
-                            <td>Chtouka-Aït Baha Province</td>
-                        </tr>
-                    </tbody>
-                </table>
+        <section class="band band--tight">
+            <div class="container">
+                <span class="kicker">Aït Moussa &middot; Chtouka confederation</span>
+                <h1 class="page-title">The two lines</h1>
+                <p class="lead">A Y-chromosome that has been in Africa for more than 65,000 years, and a mitochondrial line that crossed from Iberia before anyone in Morocco had planted a crop. Here is how they met.</p>
+
+                <ul class="section-nav">
+                    <li><a href="#deep-time">Deep time</a></li>
+                    <li><a href="#father">The father's line</a></li>
+                    <li><a href="#mother">The mother's line</a></li>
+                    <li><a href="#why">Why they don't match</a></li>
+                    <li><a href="#scenarios">Five explanations</a></li>
+                </ul>
             </div>
         </section>
 
-        <!-- Paternal Ancestry -->
-        <section class="card">
-            <h2>The Paternal Ancestry: A Deep History of the Amazigh Y-Chromosome (E-PF2546)</h2>
-            
-            <div class="image-container">
-                <img src="img/E-PF2546-map.webp" alt="E-M81 Berber Marker Distribution Across North Africa" style="width: 100%; height: auto; border-radius: 8px; box-shadow: var(--shadow);" loading="lazy" decoding="async" width="800" height="600">
-                <p class="image-caption">Geographic distribution of the E-M81 "Berber Marker" across North Africa, showing the concentration in the Maghreb region</p>
-            </div>
+        <hr class="stripe">
 
-            <h3>The African Genesis of Haplogroup E</h3>
-            <p>
-                The paternal line belongs to the macro-haplogroup E, defined by the M96 mutation. This is a primary branch of the more ancient haplogroup DE. The ultimate origin of haplogroup E has been a subject of academic discussion, but the most recent genetic evidence, including the discovery of the ancient D0 haplogroup in Nigeria, strongly supports an African origin for the entire DE clade. This places the root of this paternal lineage firmly on the African continent, with an immense time depth stretching back over <strong>65,000 years</strong>.
-            </p>
+        <!-- Deep time -->
+        <section class="band band--sunk" aria-labelledby="deep-time">
+            <div class="container">
+                <span class="section-marker" aria-hidden="true">ⵣ</span>
+                <h2 id="deep-time">Deep time, in order</h2>
+                <p class="prose">Two ancestries, six moments. The father's line is the older by a very long way — but the mother's line has been North African for roughly ten thousand years, which is longer than any written history of the region.</p>
 
-            <h3>The "Berber Marker" E-M81/E-M183</h3>
-            <p>
-                Further down the phylogenetic tree, this lineage belongs to haplogroup <strong>E-M81</strong> (also known as E1b1b1b1a), the single most dominant Y-chromosome haplogroup in North Africa and the defining paternal marker of the Amazigh people. Its geographic distribution is highly structured, displaying a pronounced west-to-east gradient:
-            </p>
-            
-            <ul style="margin: 1rem 0; padding-left: 2rem;">
-                <li>Frequencies peak in the Maghreb, reaching <strong>over 80%</strong> in some Amazigh communities (with an average of ~45% across North Africa)</li>
-                <li>In specific Moroccan Berber groups, reaches nearly <strong>98%</strong></li>
-                <li>Decreases progressively eastward into Libya and Egypt (~10%)</li>
-                <li>Found at lower frequencies in Iberia (~5% in Portugal) due to historical North African influence</li>
-            </ul>
+                <figure class="figure">
+                    <ul class="legend">
+                        <li><span class="legend__dot" style="background: var(--sea)"></span> Father's line — squares, left</li>
+                        <li><span class="legend__dot" style="background: var(--yaz)"></span> Mother's line — circles, right</li>
+                    </ul>
+                    <div class="figure__frame">
+                        <svg viewBox="0 0 900 790" role="img" aria-labelledby="dg2-title dg2-desc">
+                            <title id="dg2-title">Deep-time sequence of the two ancestral lines</title>
+                            <desc id="dg2-desc">A vertical timeline, oldest at the top. Paternal events on the left: haplogroup E arises in Africa more than 65,000 years ago; E-M81 expands across the Maghreb 2,000 to 3,000 years ago; E-PF2546 branches around 400 BCE. Maternal events on the right: H1 shelters in the Franco-Cantabrian refuge 26,500 to 19,000 years ago; H1 crosses into North Africa from Iberia 8,000 to 11,000 years ago; Iberian farmers reach the Maghreb around 7,500 years ago. Both lines converge on Aït Moussa in Souss-Massa today. Stops are ordered, not drawn to scale.</desc>
 
-            <h3>E-PF2546: A Lineage of the Mauretanian Iron Age</h3>
-            <div class="grid">
-                <div>
-                    <p>
-                        The specific subclade identified, <strong>E-PF2546</strong>, represents a distinct branch within the broader E-M81 tree. Per the YFull YTree database, E-PF2546 formed approximately <strong>2,300 years before present</strong> (~300 BCE), with a TMRCA of approximately <strong>2,100 years before present</strong>. This is consistent with the broader finding by D'Atanasio et al. (2018, <em>Scientific Reports</em>) that E-M81/E-M183 underwent a surprisingly recent expansion, with whole Y-chromosome sequencing placing the parent clade's TMRCA at ~2,000-3,000 years ago.
-                    </p>
-                    <p>
-                        This precise dating places the lineage's formation during the zenith of Carthaginian power in North Africa and the consolidation of the Mauritanian kingdoms, representing a critical period of demographic expansion and cultural development among the Amazigh peoples.
-                    </p>
-                </div>
-                <div class="image-container">
-                    <img src="img/E-PF2546-distribution.webp" alt="E-PF2546 Geographic Distribution Chart" style="width: 100%; height: auto; border-radius: 8px; box-shadow: var(--shadow);" loading="lazy" decoding="async" width="600" height="400">
-                    <p class="image-caption">E-PF2546 subclade distribution showing highest concentrations in Mauritania, Western Sahara, and Morocco</p>
-                </div>
-            </div>
-            
-            <p>
-                The geographic distribution shows highest concentrations in:
-            </p>
-            <ul style="margin: 1rem 0; padding-left: 2rem;">
-                <li><strong>Mauritania:</strong> 64%</li>
-                <li><strong>Western Sahara:</strong> 50%</li>
-                <li><strong>Morocco:</strong> 23%</li>
-            </ul>
+                            <!-- Axis -->
+                            <line x1="450" y1="34" x2="450" y2="700" stroke="var(--ink)" stroke-width="4"></line>
 
-            <p>
-                The formation of this lineage around 400 BCE places its founder in a pivotal period of North African history - the height of Carthaginian influence and the era of organized Amazigh kingdoms known as Mauretania. Ancient DNA analysis has even provided a direct link: a sample from a Guanche mummy found on Tenerife was identified as belonging to haplogroup E-PF2546, confirming this lineage's role in the ancient Amazigh expansion to the Canary Islands.
-            </p>
-        </section>
+                            <!-- 1. Father — E arises -->
+                            <rect x="438" y="58" width="24" height="24" fill="var(--sea)"></rect>
+                            <text class="dg-label" x="410" y="64" fill="var(--ink)" font-size="24" text-anchor="end">Haplogroup E arises</text>
+                            <text class="dg-label" x="410" y="90" fill="var(--ink)" font-size="24" text-anchor="end">in Africa</text>
+                            <text class="dg-meta" x="410" y="118" fill="var(--sea)" font-size="16" text-anchor="end">65,000+ years ago</text>
 
-        <!-- Maternal Ancestry -->
-        <section class="card">
-            <h2>The Maternal Ancestry: A European Journey to Africa (H1-T16189C!)</h2>
-            
-            <div class="image-container">
-                <img src="img/map-h-haplo.webp" alt="H1 Haplogroup Distribution and Migration Patterns" style="width: 100%; height: auto; border-radius: 8px; box-shadow: var(--shadow);" loading="lazy" decoding="async" width="800" height="500">
-                <p class="image-caption">H1 haplogroup distribution showing the prehistoric migration from the Franco-Cantabrian refuge to North Africa</p>
-            </div>
+                            <!-- 2. Mother — LGM refuge -->
+                            <circle cx="450" cy="192" r="13" fill="var(--yaz)"></circle>
+                            <text class="dg-label" x="490" y="174" fill="var(--ink)" font-size="24">H1 shelters in the</text>
+                            <text class="dg-label" x="490" y="200" fill="var(--ink)" font-size="24">Franco-Cantabrian refuge</text>
+                            <text class="dg-meta" x="490" y="228" fill="var(--yaz)" font-size="16">26,500–19,000 years ago</text>
 
-            <h3>Origins in Ice Age Europe: Haplogroup H1</h3>
-            <p>
-                In stark contrast to the deep African roots of the paternal line, the maternal lineage follows a journey that begins in Ice Age Europe. The maternal lineage belongs to haplogroup <strong>H1</strong>, a major subclade of haplogroup H, which is the most common mtDNA haplogroup in Europe today (found in approximately 41% of the population).
-            </p>
+                            <!-- 3. Mother — crosses the Strait -->
+                            <circle cx="450" cy="302" r="13" fill="var(--yaz)"></circle>
+                            <text class="dg-label" x="490" y="284" fill="var(--ink)" font-size="24">H1 crosses into North</text>
+                            <text class="dg-label" x="490" y="310" fill="var(--ink)" font-size="24">Africa from Iberia</text>
+                            <text class="dg-meta" x="490" y="338" fill="var(--yaz)" font-size="16">8,000–11,000 years ago</text>
 
-            <p>
-                During the Last Glacial Maximum (26,500 to 19,000 years ago), vast ice sheets forced human populations into southern refugia, such as the Franco-Cantabrian region of northern Spain and southwestern France. As the climate warmed, populations carrying haplogroup H1 expanded from this refuge to repopulate Central and Northern Europe. The coalescence age of H1 is estimated at approximately <strong>11,000-16,000 years</strong> depending on the calibration method used (Soares et al. 2010; Ottoni et al. 2010).
-            </p>
+                            <!-- 4. Mother — Neolithic farmers -->
+                            <circle cx="450" cy="412" r="13" fill="var(--yaz)"></circle>
+                            <text class="dg-label" x="490" y="394" fill="var(--ink)" font-size="24">Iberian farmers reach</text>
+                            <text class="dg-label" x="490" y="420" fill="var(--ink)" font-size="24">the Maghreb</text>
+                            <text class="dg-meta" x="490" y="448" fill="var(--yaz)" font-size="16">~7,500 years ago</text>
 
-            <h3>Across the Strait: The Prehistoric Migration into North Africa</h3>
-            <div class="grid">
-                <div>
-                    <p>
-                        Critically, this post-glacial expansion was not only northward into Europe but also southward across the Strait of Gibraltar. This migration was so substantial that H1 became the dominant subclade of haplogroup H in North Africa, accounting for <strong>42% of H lineages</strong> in the region.
-                    </p>
-                </div>
-                <div class="image-container">
-                    <img src="img/map-h-haplo.webp" alt="Prehistoric Migration Routes from Iberia to North Africa" style="width: 100%; height: auto; border-radius: 8px; box-shadow: var(--shadow);" loading="lazy" decoding="async" width="800" height="500">
-                    <p class="image-caption">Migration pathways showing how H1 lineages crossed from Iberia to establish in North Africa during the early Holocene</p>
-                </div>
-            </div>
+                            <!-- 5. Father — E-M81 starburst -->
+                            <rect x="438" y="510" width="24" height="24" fill="var(--sea)"></rect>
+                            <text class="dg-label" x="410" y="516" fill="var(--ink)" font-size="24" text-anchor="end">E-M81 expands fast</text>
+                            <text class="dg-label" x="410" y="542" fill="var(--ink)" font-size="24" text-anchor="end">across the Maghreb</text>
+                            <text class="dg-meta" x="410" y="570" fill="var(--sea)" font-size="16" text-anchor="end">2,000–3,000 years ago</text>
 
-            <p>
-                The timing of this migration is crucial: the coalescence age for haplogroup H1 within North Africa is approximately <strong>11,400 years ago</strong> (range: ~9,000-13,700 years ago) as estimated by Ottoni et al. (2010, <em>PLOS ONE</em>). This firmly places its arrival in the early Holocene — during the African Humid Period when the Sahara was much greener — long before any historical migrations. Villalba-Mouco et al. (2023, <em>Nature</em>) provided direct ancient DNA confirmation that early Neolithic Moroccans carried European Neolithic ancestry, supporting trans-Gibraltar gene flow. Complementing this, Lipson et al. (2025, <em>Nature</em>) showed that Neolithic groups in eastern Maghreb (Algeria/Tunisia) retained predominantly local forager ancestry, with only limited farmer-related inputs. Together, these results support a continuity-with-contact model rather than wholesale replacement during the Neolithic transition.
-            </p>
+                            <!-- 6. Father — E-PF2546 -->
+                            <rect x="438" y="620" width="24" height="24" fill="var(--sea)"></rect>
+                            <text class="dg-label" x="410" y="626" fill="var(--ink)" font-size="24" text-anchor="end">E-PF2546 branches</text>
+                            <text class="dg-label" x="410" y="652" fill="var(--ink)" font-size="24" text-anchor="end">in Mauretanian Iron Age</text>
+                            <text class="dg-meta" x="410" y="680" fill="var(--sea)" font-size="16" text-anchor="end">~400 BCE</text>
 
-            <h3>The H1-T16189C! Marker and Local Evolution</h3>
-            <p>
-                The ancient presence of H1 in North Africa is confirmed by the evolution of local, North Africa-specific subclades such as H1v, H1w, and H1x (Ottoni et al. 2010). These subclades have been confirmed in recent studies: Colombo et al. (2025, <em>Scientific Reports</em>) found North African-specific H1 clades at frequencies of 4.4-15.4% across the region, while Aizpurua-Iraola et al. (2023, <em>Scientific Reports</em>) confirmed them in Algerian Chaoui Imazighen populations. The specific marker <strong>T16189C</strong> defines a particular branch within the H1 tree and has been found in ancient DNA samples from Poland dating to around 1,750 years before present (Juras et al. 2014, <em>PLOS ONE</em>), confirming its ancient European presence.
-            </p>
-        </section>
-
-        <!-- Tribal Context -->
-        <section class="card">
-            <h2 style="color: var(--primary-color); font-size: 2.5rem; font-weight: 900; margin-bottom: 2rem; text-align: center;">Ethnohistory of the Chtouka</h2>
-            <p class="text-large text-center mb-2" style="max-width: 800px; margin: 0 auto 2rem;">
-                Your specific origins place you within the Chtouka (Aït Chtouk), a major tribal confederation of the Tachelhit-speaking Amazigh people. This is the heartland of the Shilha culture in the Souss-Massa region.
-            </p>
-            
-            <div class="argan-landscape" style="margin: 2rem 0;">
-                <img src="img/chtouka-village.webp" alt="Traditional Chtouka Amazigh village in Souss Valley showing earthen architecture with fortified agadir granary (igoudar) used for storing food and valuables" width="1200" height="350" style="width: 100%; height: 350px; object-fit: cover; border-radius: 12px; box-shadow: 0 8px 24px rgba(0,0,0,0.15);" loading="lazy">
-                <p style="text-align: center; margin-top: 1rem; font-style: italic; color: var(--text-secondary); font-size: 0.95rem;">
-                    <strong>🏛️ Traditional Chtouka Village:</strong> Earthen architecture with fortified agadir granary in the Souss Valley
-                </p>
-            </div>
-
-            <div class="grid">
-                <div class="card">
-                    <h3 style="color: var(--secondary-color); text-align: center; margin-bottom: 2rem;">Tribal & Cultural Identity</h3>
-                    <div style="display: flex; flex-direction: column; gap: 1rem; text-align: center;">
-                        <div style="background: linear-gradient(135deg, var(--background-color), var(--border)); padding: 1.5rem; border-radius: var(--border-radius); box-shadow: var(--shadow);">
-                            <h4 style="color: var(--text-color); opacity: 0.7; margin-bottom: 0.5rem;">Confederation</h4>
-                            <p style="font-size: 1.5rem; font-weight: bold; color: var(--secondary-color);">Aït Chtouk (Chtouka)</p>
-                        </div>
-                        <div style="display: flex; justify-content: center;">
-                            <span style="font-size: 2rem; color: var(--primary-color);">&darr;</span>
-                        </div>
-                        <div style="background: linear-gradient(135deg, var(--background-color), var(--border)); padding: 1.5rem; border-radius: var(--border-radius); box-shadow: var(--shadow);">
-                            <h4 style="color: var(--text-color); opacity: 0.7; margin-bottom: 0.5rem;">Territory</h4>
-                            <p style="font-size: 1.5rem; font-weight: bold; color: var(--secondary-color);">Chtouka-Aït Baha Province</p>
-                        </div>
-                        <div style="display: flex; justify-content: center;">
-                            <span style="font-size: 2rem; color: var(--primary-color);">&darr;</span>
-                        </div>
-                        <div style="background: linear-gradient(135deg, var(--background-color), var(--border)); padding: 1.5rem; border-radius: var(--border-radius); box-shadow: var(--shadow);">
-                            <h4 style="color: var(--text-color); opacity: 0.7; margin-bottom: 0.5rem;">Geographic Center</h4>
-                            <p style="font-size: 1.5rem; font-weight: bold; color: var(--secondary-color);">Souss Valley</p>
-                        </div>
+                            <!-- Convergence -->
+                            <rect x="235" y="700" width="430" height="62" fill="var(--mountain)"></rect>
+                            <text class="dg-label" x="450" y="727" fill="var(--on-colour)" font-size="24" text-anchor="middle">AÏT MOUSSA — TODAY</text>
+                            <text class="dg-body" x="450" y="750" fill="var(--on-colour)" font-size="18" text-anchor="middle">both lines, one family</text>
+                        </svg>
                     </div>
-                </div>
-                
-                <div class="card">
-                    <h3 style="color: var(--secondary-color); text-align: center; margin-bottom: 2rem;">Pillars of Souss Culture</h3>
-                    <p style="color: var(--text-color); margin-bottom: 2rem;">
-                        The Chtouka tribes are sedentary agriculturalists and pastoralists, whose society was traditionally built around key cultural and economic pillars.
-                    </p>
-                    <div style="display: flex; flex-direction: column; gap: 1.5rem;">
-                        <div style="display: flex; align-items: start; padding: 1.5rem; background: rgba(226, 163, 107, 0.1); border-radius: var(--border-radius);">
-                            <span style="font-size: 2rem; margin-right: 1rem;">&#127963;</span>
-                            <div>
-                                <h4 style="color: var(--secondary-color); font-weight: bold; margin-bottom: 0.5rem;">The Agadir (Igoudar)</h4>
-                                <p style="color: var(--text-color);">Iconic collective, fortified granaries used by the tribe to protect food, valuables, and manuscripts.</p>
-                            </div>
-                        </div>
-                        <div style="display: flex; align-items: start; padding: 1.5rem; background: rgba(255, 209, 102, 0.1); border-radius: var(--border-radius);">
-                            <span style="font-size: 2rem; margin-right: 1rem;">&#129750;</span>
-                            <div>
-                                <h4 style="color: var(--secondary-color); font-weight: bold; margin-bottom: 0.5rem;">Argan Oil Production</h4>
-                                <p style="color: var(--text-color);">A foundational economic and culinary resource unique to the Souss region.</p>
-                            </div>
-                        </div>
-                        <div style="display: flex; align-items: start; padding: 1.5rem; background: rgba(205, 127, 50, 0.1); border-radius: var(--border-radius);">
-                            <span style="font-size: 2rem; margin-right: 1rem;">&#128172;</span>
-                            <div>
-                                <h4 style="color: var(--secondary-color); font-weight: bold; margin-bottom: 0.5rem;">Tachelhit Language</h4>
-                                <p style="color: var(--text-color);">The Amazigh language of the Shilha people, preserving ancient oral traditions and poetry.</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <p style="color: var(--text-color); margin-top: 2rem; text-align: center; font-style: italic;">
-                A particularly notable cultural element throughout the Chtouka region is the weaving tradition. Chtouka women are renowned for producing spectacular striated textiles (haik and tahaikt) on vertical looms, with purely decorative striped patterns that focus on creative expression rather than protective functions common in other Berber traditions.
-            </p>
-        </section>
-
-        <!-- Historical Timeline -->
-        <section class="card">
-            <h2 style="color: var(--primary-color); font-size: 2.5rem; font-weight: 900; margin-bottom: 2rem; text-align: center;">Political & Linguistic Timeline</h2>
-            <p class="text-large text-center mb-2" style="max-width: 800px; margin: 0 auto 2rem;">
-                The Souss region has a complex history, balancing tribal autonomy with the authority of central governments. This timeline highlights the political evolution that your ancestors experienced.
-            </p>
-            
-            <div class="image-container" style="margin: 2rem 0;">
-                <img src="img/migration-timeline.webp" alt="Historical migration timeline visualization showing human movements across North Africa and Mediterranean, including Neolithic and Iron Age population flows" width="1200" height="400" style="width: 100%; height: 400px; object-fit: cover; border-radius: 12px; box-shadow: 0 8px 24px rgba(0,0,0,0.15);" loading="lazy">
-                <p class="image-caption">Migration patterns and historical movements: Visual representation of population flows into and across North Africa</p>
-            </div>
-            
-            <!-- Modern Clean Timeline -->
-            <div style="position: relative; padding: 2rem 0;">
-                <!-- Timeline Line -->
-                <div style="position: absolute; top: 20px; left: 5%; right: 5%; height: 2px; background: var(--border);"></div>
-                
-                <!-- Timeline Events -->
-                <div class="era-timeline">
-                    <!-- Event 1 -->
-                    <div style="position: relative;">
-                        <div style="width: 12px; height: 12px; background: #D4A629; border-radius: 50%; margin: 0 auto 2rem; position: relative; z-index: 1;"></div>
-                        <div style="background: var(--background-alt); padding: 1.5rem; border-radius: 8px;">
-                            <div style="font-size: 0.7rem; color: var(--text-secondary); font-weight: 600; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 0.75rem;">1000 BCE - 700 CE</div>
-                            <h3 class="timeline-era-title">Pre-Islamic Era</h3>
-                            <p style="font-size: 0.85rem; line-height: 1.6; color: var(--text-secondary); margin-bottom: 0.75rem;"><strong style="color: var(--text-primary);">Politics:</strong> Amazigh tribal autonomy. Interaction with Phoenician, Carthaginian, Roman settlements.</p>
-                            <p style="font-size: 0.85rem; line-height: 1.6; color: var(--text-secondary);"><strong style="color: var(--text-primary);">Culture:</strong> Tachelhit dominant. Libyco-Berber script in use.</p>
-                        </div>
-                    </div>
-                    
-                    <!-- Event 2 -->
-                    <div style="position: relative;">
-                        <div style="width: 12px; height: 12px; background: #E2A36B; border-radius: 50%; margin: 0 auto 2rem; position: relative; z-index: 1;"></div>
-                        <div style="background: var(--background-alt); padding: 1.5rem; border-radius: 8px;">
-                            <div style="font-size: 0.7rem; color: var(--text-secondary); font-weight: 600; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 0.75rem;">1040 - 1500 CE</div>
-                            <h3 class="timeline-era-title">Medieval Dynasties</h3>
-                            <p style="font-size: 0.85rem; line-height: 1.6; color: var(--text-secondary); margin-bottom: 0.75rem;"><strong style="color: var(--text-primary);">Politics:</strong> Cradle of Almoravids and Almohads. Integrated into Moroccan empires.</p>
-                            <p style="font-size: 0.85rem; line-height: 1.6; color: var(--text-secondary);"><strong style="color: var(--text-primary);">Culture:</strong> Islamization. Tachelhit literary tradition emerges with Arabic script.</p>
-                        </div>
-                    </div>
-                    
-                    <!-- Event 3 -->
-                    <div style="position: relative;">
-                        <div style="width: 12px; height: 12px; background: #E4C258; border-radius: 50%; margin: 0 auto 2rem; position: relative; z-index: 1;"></div>
-                        <div style="background: var(--background-alt); padding: 1.5rem; border-radius: 8px;">
-                            <div style="font-size: 0.7rem; color: var(--text-secondary); font-weight: 600; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 0.75rem;">1600 - 1912 CE</div>
-                            <h3 class="timeline-era-title">Siba & Makhzen</h3>
-                            <p style="font-size: 0.85rem; line-height: 1.6; color: var(--text-secondary); margin-bottom: 0.75rem;"><strong style="color: var(--text-primary);">Politics:</strong> Chtouka tribes in <em>Siba</em> (dissidence). Self-governance via Jemaas and Amghars.</p>
-                            <p style="font-size: 0.85rem; line-height: 1.6; color: var(--text-secondary);"><strong style="color: var(--text-primary);">Culture:</strong> Rich oral and written Tachelhit poetic traditions.</p>
-                        </div>
-                    </div>
-                    
-                    <!-- Event 4 -->
-                    <div style="position: relative;">
-                        <div style="width: 12px; height: 12px; background: var(--primary-terracotta); border-radius: 50%; margin: 0 auto 2rem; position: relative; z-index: 1;"></div>
-                        <div style="background: var(--background-alt); padding: 1.5rem; border-radius: 8px;">
-                            <div style="font-size: 0.7rem; color: var(--text-secondary); font-weight: 600; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 0.75rem;">1912 - 1956 CE</div>
-                            <h3 class="timeline-era-title">French Protectorate</h3>
-                            <p style="font-size: 0.85rem; line-height: 1.6; color: var(--text-secondary); margin-bottom: 0.75rem;"><strong style="color: var(--text-primary);">Politics:</strong> Colonial rule. Souss among last to be "pacified." Indirect administration.</p>
-                            <p style="font-size: 0.85rem; line-height: 1.6; color: var(--text-secondary);"><strong style="color: var(--text-primary);">Culture:</strong> French as administrative language. Post-independence Arabization.</p>
-                        </div>
-                    </div>
-                    
-                    <!-- Event 5 -->
-                    <div style="position: relative;">
-                        <div style="width: 12px; height: 12px; background: #8B5CF6; border-radius: 50%; margin: 0 auto 2rem; position: relative; z-index: 1;"></div>
-                        <div style="background: var(--background-alt); padding: 1.5rem; border-radius: 8px;">
-                            <div style="font-size: 0.7rem; color: var(--text-secondary); font-weight: 600; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 0.75rem;">1956 CE - Present</div>
-                            <h3 class="timeline-era-title">Post-Independence</h3>
-                            <p style="font-size: 0.85rem; line-height: 1.6; color: var(--text-secondary); margin-bottom: 0.75rem;"><strong style="color: var(--text-primary);">Politics:</strong> Integration into modern Kingdom of Morocco. Amazigh autonomy movements.</p>
-                            <p style="font-size: 0.85rem; line-height: 1.6; color: var(--text-secondary);"><strong style="color: var(--text-primary);">Culture:</strong> 21st century: Official recognition of Amazigh language and identity.</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            
-            <!-- Linguistic Highlight -->
-            <div style="background: linear-gradient(135deg, #D4A629, #E4C258); padding: 3rem; border-radius: 16px; text-align: center; margin-top: 3rem; color: white;">
-                <div style="font-size: 4rem; margin-bottom: 1rem;">💬</div>
-                <h3 style="font-size: 2.5rem; font-weight: 900; margin-bottom: 1rem; color: white;">Tachelhit</h3>
-                <p style="font-size: 1.1rem; max-width: 700px; margin: 0 auto; line-height: 1.7;">
-                    The Amazigh language of your ancestors. Its persistence in the Souss, despite centuries of interaction with Moroccan Arabic (Darija), demonstrates the deep cultural resilience of the Shilha people.
-                </p>
+                    <figcaption class="figure__caption"><b>Stops are in order, not to scale.</b> Compressing 65,000 years onto one axis at true scale would leave every event after the Ice Age stacked in the last few pixels. Each date is an estimate with a published range, shown in full above.</figcaption>
+                </figure>
             </div>
         </section>
 
-        <!-- Genetic Synthesis -->
-        <section class="card">
-            <h2>Genetic Synthesis: The "H1 Enigma" and the Peopling of North Africa</h2>
-            
-            <div style="max-width: 600px; margin: 2rem auto;">
-                <div style="height: 300px;">
-                    <canvas id="admixtureChart"></canvas>
-                </div>
-                <p style="text-align: center; font-size: 0.875rem; color: var(--text-secondary); font-style: italic; margin-top: 1rem; margin-bottom: 2rem; line-height: 1.5;">Asymmetrical admixture pattern showing the different origins of paternal (African) and maternal (European) lineages</p>
-            </div>
+        <!-- The father's line -->
+        <section class="band" aria-labelledby="father">
+            <div class="container">
+                <span class="section-marker" aria-hidden="true">ⵣ</span>
+                <h2 id="father">The father's line: <span class="hg">E-PF2546</span></h2>
 
-            <h3>Asymmetrical Admixture and Female-Mediated Gene Flow</h3>
-            <p>
-                The genetic profile of this lineage—combining indigenous Amazigh Y-DNA E-M81 with European-origin mtDNA H1—exemplifies <strong>asymmetrical admixture</strong>. This demographic pattern shows unequal genetic contributions from males and females of different source populations, suggesting historical scenarios where incoming groups consisted primarily of women integrated into existing male-dominated social structures.
-            </p>
-
-            <h3>Evaluating Historical Scenarios</h3>
-            <p>
-                Several events could explain the introduction of European maternal lineages into North Africa:
-            </p>
-
-            <div class="era-grid-3">
-                <div style="background: #F0FDF4; padding: 1.75rem; border-radius: 10px;">
-                    <div style="font-size: 2rem; margin-bottom: 0.75rem;">✅</div>
-                    <h4 style="color: #166534; font-weight: 700; font-size: 1rem; margin-bottom: 1rem; line-height: 1.3;">Early Holocene / Neolithic Migrations (~8,000-11,000 years ago)</h4>
-                    <div style="display: inline-block; background: #15803D; color: white; padding: 0.25rem 0.75rem; border-radius: 4px; font-size: 0.75rem; font-weight: 600; margin-bottom: 1rem;">MOST LIKELY</div>
-                    <p style="font-size: 0.875rem; line-height: 1.6; color: #15803D;">Coalescence dates for H1 in North Africa align with this period. Villalba-Mouco et al. (2023, <em>Nature</em>) confirmed via ancient DNA that early Neolithic Moroccans carried European Neolithic ancestry, supporting Iberian migration across the Strait of Gibraltar through sex-biased gene flow.</p>
+                <div class="split">
+                    <div class="block block--sea">
+                        <h3>It never left</h3>
+                        <p class="mb-0">The paternal line belongs to haplogroup E, defined by the M96 mutation. Recent evidence — including the discovery of the ancient D0 haplogroup in Nigeria — supports an African origin for the whole DE clade, placing this line's root on the continent more than 65,000 years ago.</p>
+                    </div>
+                    <div class="block">
+                        <h3>The Amazigh marker</h3>
+                        <p class="mb-0">Further down the tree sits <span class="hg">E-M81</span>, the dominant Y-chromosome across North Africa and the defining paternal marker of the Amazigh. It exceeds 80% in the Maghreb and approaches 98% in some Moroccan Amazigh groups, thinning eastward towards Egypt.</p>
+                    </div>
                 </div>
 
-                <div style="background: #FEF3C7; padding: 1.75rem; border-radius: 10px;">
-                    <div style="font-size: 2rem; margin-bottom: 0.75rem;">⚠️</div>
-                    <h4 style="color: #92400E; font-weight: 700; font-size: 1rem; margin-bottom: 1rem; line-height: 1.3;">Bell Beaker Cultural Diffusion (~4,500 years ago)</h4>
-                    <div style="display: inline-block; background: #B45309; color: white; padding: 0.25rem 0.75rem; border-radius: 4px; font-size: 0.75rem; font-weight: 600; margin-bottom: 1rem;">UNLIKELY</div>
-                    <p style="font-size: 0.875rem; line-height: 1.6; color: #B45309;">While Bell Beaker involved Iberia-Morocco contacts, its European legacy is primarily male-biased R1b expansion, making it an unlikely source for maternal H1.</p>
+                <div class="stack" style="margin-top: var(--gap)">
+                    <p class="prose">The surprise is how <em>recent</em> it is. Whole Y-chromosome sequencing revised <span class="hg">E-M81</span>'s time to most recent common ancestor down to roughly <strong>2,000–3,000 years ago</strong>, and its star-like variation points to a rapid expansion from a small founder group in the late Bronze or early Iron Age (<a href="research/e-m183-recent-origin-2018.html">Solé-Morata et al. 2017</a>).</p>
+
+                    <p class="prose">Within that, <span class="hg">E-PF2546</span> split from its parent clade around 500 BCE and coalesces at approximately <strong>400 BCE</strong> — the era of the independent Amazigh kingdoms of Mauretania, when Carthage held the coast and the hinterland governed itself. An ancient-DNA sample from a Guanche individual on Tenerife has been assigned to this same subclade in public ancient-DNA datasets, which would place it among the Amazigh who sailed to settle the <a href="research/canary-islands-amazigh-history-2025.html">Canary Islands</a>.</p>
                 </div>
 
-                <div style="background: #FEF2F2; padding: 1.75rem; border-radius: 10px;">
-                    <div style="font-size: 2rem; margin-bottom: 0.75rem;">❌</div>
-                    <h4 style="color: #991B1B; font-weight: 700; font-size: 1rem; margin-bottom: 1rem; line-height: 1.3;">Roman/Vandal/Islamic Periods</h4>
-                    <div style="display: inline-block; background: #B91C1C; color: white; padding: 0.25rem 0.75rem; border-radius: 4px; font-size: 0.75rem; font-weight: 600; margin-bottom: 1rem;">TOO RECENT</div>
-                    <p style="font-size: 0.875rem; line-height: 1.6; color: #B91C1C;">These historical migrations are far too recent to account for H1's deep coalescence dates and local subclade evolution in North Africa.</p>
-                </div>
-            </div>
+                <figure class="figure" style="margin-top: var(--gap)">
+                    <div class="figure__frame">
+                        <svg viewBox="0 0 900 300" role="img" aria-labelledby="dg3-title dg3-desc">
+                            <title id="dg3-title">E-PF2546 frequency by region</title>
+                            <desc id="dg3-desc">Reported frequency of haplogroup E-PF2546: Mauritania 64 percent, Western Sahara 50 percent, Morocco 23 percent.</desc>
 
-            <h3>Conclusion: The Confluence of Two Histories</h3>
-            <p class="text-large">
-                The current academic consensus supports that haplogroup H1 became embedded in the North African maternal gene pool through significant, female-mediated migration from Iberia during the prehistoric Neolithic period. This was not violent conquest but demic diffusion and admixture, where women from farming communities integrated with local North African groups.
-            </p>
+                            <text class="dg-meta" x="0" y="20" fill="var(--ink-quiet)" font-size="16">Share of men carrying E-PF2546</text>
 
-            <div class="heritage-map" style="margin: 2.5rem 0;">
-                <img src="img/haplogroup-map.webp" alt="Genetic heritage convergence map showing E-PF2546 Y-DNA and H1 mtDNA haplogroup migration patterns from Africa and Europe converging in Souss-Massa, Morocco" width="1200" height="450" style="width: 100%; height: 450px; object-fit: cover; border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,0.2);" loading="lazy">
-                <p class="image-caption" style="text-align: center; margin-top: 1rem; font-style: italic; color: var(--text-secondary); font-size: 0.95rem;">
-                    <strong>🧬 Heritage Convergence:</strong> Visualization of how the paternal E-PF2546 (African) and maternal H1 (European) lineages converged in the Souss-Massa region over thousands of years
-                </p>
-            </div>
+                            <!-- Mauritania 64% -->
+                            <text class="dg-label" x="0" y="76" fill="var(--ink)" font-size="23">Mauritania</text>
+                            <rect x="230" y="54" width="429" height="32" fill="var(--sea)"></rect>
+                            <text class="dg-meta" x="675" y="77" fill="var(--ink)" font-size="19">64%</text>
 
-            <p>
-                The genetic profile analyzed represents a living testament to this deep history. The paternal E-PF2546 lineage embodies the ancient, autochthonous Amazigh heritage - men who inhabited the Souss-Massa for millennia, underwent massive Iron Age expansion, and maintained cultural autonomy for centuries. The maternal H1 lineage represents the legacy of a foundational prehistoric migration of women from Europe, whose descendants became fully integrated into North African populations thousands of years before recorded history.
-            </p>
+                            <!-- Western Sahara 50% -->
+                            <text class="dg-label" x="0" y="156" fill="var(--ink)" font-size="23">Western Sahara</text>
+                            <rect x="230" y="134" width="335" height="32" fill="var(--sea)"></rect>
+                            <text class="dg-meta" x="581" y="157" fill="var(--ink)" font-size="19">50%</text>
 
-            <p class="highlight">
-                <strong>The convergence of these two distinct yet interwoven streams of human history in an individual from the Chtouka confederation is the remarkable culmination of this grand demographic narrative.</strong>
-            </p>
-        </section>
+                            <!-- Morocco 23% -->
+                            <text class="dg-label" x="0" y="236" fill="var(--ink)" font-size="23">Morocco</text>
+                            <rect x="230" y="214" width="154" height="32" fill="var(--sea)"></rect>
+                            <text class="dg-meta" x="400" y="237" fill="var(--ink)" font-size="19">23%</text>
 
-        <!-- References -->
-        <section class="card">
-            <h2>References &amp; Further Reading</h2>
-            <div style="font-size: 0.9rem; line-height: 1.8; color: var(--text-secondary);">
-                <ol style="padding-left: 1.5rem;">
-                    <li>D'Atanasio, E. et al. (2018). Whole Y-chromosome sequences reveal an extremely recent origin of the most common North African paternal lineage E-M183 (M81). <em>Scientific Reports</em>, 8, 15941. DOI: <a href="https://doi.org/10.1038/s41598-017-16271-y" target="_blank" rel="noopener">10.1038/s41598-017-16271-y</a></li>
-                    <li>Ottoni, C. et al. (2010). Mitochondrial Haplogroup H1 in North Africa: An Early Holocene Arrival from Iberia. <em>PLOS ONE</em>, 5(10), e13378. DOI: <a href="https://doi.org/10.1371/journal.pone.0013378" target="_blank" rel="noopener">10.1371/journal.pone.0013378</a></li>
-                    <li>Ennafaa, H. et al. (2009). Mitochondrial DNA haplogroup H structure in North Africa. <em>BMC Genetics</em>, 10, 8. DOI: <a href="https://doi.org/10.1186/1471-2156-10-8" target="_blank" rel="noopener">10.1186/1471-2156-10-8</a></li>
-                    <li>Villalba-Mouco, V. et al. (2023). Northwest African Neolithic initiated by migrants from Iberia and Levant. <em>Nature</em>, 618, 550-556. DOI: <a href="https://doi.org/10.1038/s41586-023-06166-6" target="_blank" rel="noopener">10.1038/s41586-023-06166-6</a></li>
-                    <li>Lipson, M. et al. (2025). High continuity of forager ancestry in the Neolithic period of the eastern Maghreb. <em>Nature</em>, 641, 925-931. DOI: <a href="https://doi.org/10.1038/s41586-025-08699-4" target="_blank" rel="noopener">10.1038/s41586-025-08699-4</a></li>
-                    <li>Salem, N. et al. (2025). Ancient DNA from the Green Sahara reveals ancestral North African lineage. <em>Nature</em>, 641, 144-150. DOI: <a href="https://doi.org/10.1038/s41586-025-08793-7" target="_blank" rel="noopener">10.1038/s41586-025-08793-7</a></li>
-                    <li>Colombo, G. et al. (2025). The origin of modern North Africans as depicted by a massive survey of mitogenomes. <em>Scientific Reports</em>, 15, 27025. DOI: <a href="https://doi.org/10.1038/s41598-025-12209-x" target="_blank" rel="noopener">10.1038/s41598-025-12209-x</a></li>
-                    <li>Aizpurua-Iraola, J. et al. (2023). Whole mitogenomes reveal that NW Africa has acted both as a source and a destination for multiple human movements. <em>Scientific Reports</em>, 13, 9566. DOI: <a href="https://doi.org/10.1038/s41598-023-37549-4" target="_blank" rel="noopener">10.1038/s41598-023-37549-4</a></li>
-                    <li>Fregel, R. et al. (2018). Ancient genomes from North Africa evidence prehistoric migrations to the Maghreb from both the Levant and Europe. <em>PNAS</em>, 115(26), 6774-6779. DOI: <a href="https://doi.org/10.1073/pnas.1800851115" target="_blank" rel="noopener">10.1073/pnas.1800851115</a></li>
-                    <li>van de Loosdrecht, M. et al. (2018). Pleistocene North African genomes link Near Eastern and sub-Saharan African human populations. <em>Science</em>, 360(6388), 548-552. DOI: <a href="https://doi.org/10.1126/science.aar8380" target="_blank" rel="noopener">10.1126/science.aar8380</a></li>
-                    <li>Juras, A. et al. (2014). Ancient DNA Reveals Matrilineal Continuity in Present-Day Poland over the Last Two Millennia. <em>PLOS ONE</em>, 9(10), e110839. DOI: <a href="https://doi.org/10.1371/journal.pone.0110839" target="_blank" rel="noopener">10.1371/journal.pone.0110839</a></li>
-                    <li>Soares, P. et al. (2010). The Archaeogenetics of Europe. <em>Current Biology</em>, 20(4), R174-R183. DOI: <a href="https://doi.org/10.1016/j.cub.2009.11.054" target="_blank" rel="noopener">10.1016/j.cub.2009.11.054</a></li>
-                    <li>YFull YTree. E-PF2546 haplogroup entry. <a href="https://www.yfull.com/tree/E-PF2546/" target="_blank" rel="noopener">https://www.yfull.com/tree/E-PF2546/</a></li>
-                </ol>
+                            <!-- Baseline -->
+                            <line x1="230" y1="270" x2="900" y2="270" stroke="var(--ink)" stroke-width="2"></line>
+                            <text class="dg-meta" x="230" y="292" fill="var(--ink-quiet)" font-size="15">0%</text>
+                            <text class="dg-meta" x="900" y="292" fill="var(--ink-quiet)" font-size="15" text-anchor="end">100%</text>
+                        </svg>
+                    </div>
+                    <figcaption class="figure__caption"><b>The branch is concentrated in the far west.</b> Frequencies are highest in Mauritania and the Western Sahara and lower across Morocco as a whole — the distribution you would expect of a lineage that expanded from a western founder population. Figures via FamilyTreeDNA Discover; sample sizes vary by region, so treat them as indicative.</figcaption>
+                </figure>
             </div>
         </section>
 
-        <!-- Navigation -->
-        <section class="card text-center">
-            <h2>Continue Exploring</h2>
-            <div style="display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap;">
-                <a href="index.html" class="btn">Return to Homepage</a>
-                <a href="#genetics" class="btn">Genetic Analysis</a>
-                <a href="#culture" class="btn">Cultural Heritage</a>
+        <!-- The mother's line -->
+        <section class="band band--sunk" aria-labelledby="mother">
+            <div class="container">
+                <span class="section-marker" aria-hidden="true">ⵣ</span>
+                <h2 id="mother">The mother's line: <span class="hg">H1-T16189C!</span></h2>
+
+                <div class="split">
+                    <div class="block block--yaz">
+                        <h3>Born in the Ice Age</h3>
+                        <p class="mb-0">Haplogroup H is the most common maternal lineage in Europe, carried by roughly 41% of the population. Its H1 branch is tied to the Franco-Cantabrian refuge, where people sheltered through the Last Glacial Maximum, 26,500–19,000 years ago, before repopulating the continent. H1 coalesces around 11,000 years ago.</p>
+                    </div>
+                    <div class="block">
+                        <h3>It went south, too</h3>
+                        <p class="mb-0">That expansion was not only northward. A concurrent movement crossed the Strait of Gibraltar, carrying H1 from Iberia into North Africa, where it became the dominant subclade of H — 42% of all H lineages, highest in Morocco and thinning eastward (<a href="https://doi.org/10.1371/journal.pone.0013378">Ottoni et al. 2010</a>).</p>
+                    </div>
+                </div>
+
+                <div class="stack" style="margin-top: var(--gap)">
+                    <p class="prose">The timing matters more than the origin. H1 coalesces in North Africa an estimated <strong>8,000–11,000 years ago</strong> — the early Holocene, thousands of years before the Phoenicians, Romans, Vandals or Arabs. North-Africa-specific subclades such as H1v, H1w and H1x then evolved locally, in place, over millennia.</p>
+
+                    <p class="prose">See also our summary of <a href="research/north-africa-maternal-diversity-2026.html">North African maternal diversity (Boumajdi et al. 2026)</a>.</p>
+
+                    <p class="prose">So <span class="hg">H1-T16189C!</span> is not the trace of a recent European ancestor. It belongs to a lineage that has been North African for close to ten thousand years. The <span class="hg">T16189C</span> marker itself is a well-documented control-region polymorphism; it has been studied for possible metabolic associations, but its relevance here is purely genealogical.</p>
+                </div>
             </div>
         </section>
+
+        <!-- Why they don't match -->
+        <section class="band band--ink" aria-labelledby="why">
+            <div class="container">
+                <span class="kicker">The H1 enigma</span>
+                <h2 id="why">Why the two lines don't match</h2>
+                <div class="prose">
+                    <p>An African father-line beside a European mother-line looks like a contradiction. It is not. It is a textbook case of <strong>asymmetrical admixture</strong>: two populations mixed, but men and women did not contribute equally.</p>
+                    <p>Across the Maghreb the pattern is consistent — overwhelmingly local paternal lineages, alongside a substantial minority of Eurasian maternal ones. That is the signature of female-mediated gene flow into a patrilocal society: men tended to stay where they were born, so the male gene pool stayed put, while incoming women were absorbed into existing communities.</p>
+                    <p class="mb-0">Stated plainly: the local men's line persisted, and it was the arriving women's lines that were added.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Scenarios -->
+        <section class="band" aria-labelledby="scenarios">
+            <div class="container">
+                <span class="section-marker" aria-hidden="true">ⵣ</span>
+                <h2 id="scenarios">Five explanations. One survives.</h2>
+                <p class="prose">Several documented migrations could in principle have carried European maternal lines into North Africa. Tested against the coalescence dates, only one fits.</p>
+
+                <div class="table-scroll">
+                    <table class="scenarios">
+                        <caption class="figure__caption" style="text-align: left; caption-side: bottom; margin-top: 0.85rem;"><b>The dates do the deciding.</b> Any candidate has to be old enough to explain a lineage that coalesced 8,000–11,000 years ago and then evolved its own local subclades. Four of the five are far too recent.</caption>
+                        <thead>
+                            <tr>
+                                <th scope="col">Scenario</th>
+                                <th scope="col">When</th>
+                                <th scope="col">Verdict</th>
+                                <th scope="col">Why</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <th scope="row">Neolithic migration from Iberia</th>
+                                <td>~7,500 years ago</td>
+                                <td><span class="verdict verdict--yes">Fits</span></td>
+                                <td>Ancient DNA confirms Early European Farmers moved from Iberia into the Maghreb, and the movement was sex-biased. The dates line up with H1's coalescence.</td>
+                            </tr>
+                            <tr>
+                                <th scope="row">Bell Beaker diffusion</th>
+                                <td>~4,500 years ago</td>
+                                <td><span class="verdict verdict--no">Unlikely</span></td>
+                                <td>Its genetic legacy is a male-biased expansion of Y-DNA R1b — the wrong signature for introducing a major maternal lineage.</td>
+                            </tr>
+                            <tr>
+                                <th scope="row">Roman-era movement</th>
+                                <td>~2,000 years ago</td>
+                                <td><span class="verdict verdict--no">Too recent</span></td>
+                                <td>Far too late for H1's coalescence dates, and too small to seed a haplogroup at 10–20% of the maternal pool.</td>
+                            </tr>
+                            <tr>
+                                <th scope="row">Vandal and Alan migration</th>
+                                <td>5th century CE</td>
+                                <td><span class="verdict verdict--no">Negligible</span></td>
+                                <td>Roughly 80,000 people forming a temporary ruling elite over millions. Long-term genetic impact considered negligible.</td>
+                            </tr>
+                            <tr>
+                                <th scope="row">Moorish expansion and Reconquista</th>
+                                <td>8th–17th c. CE</td>
+                                <td><span class="verdict verdict--no">Wrong way</span></td>
+                                <td>The measured flow runs the other direction — North African lineages into Iberia. And it postdates H1 in the Maghreb by thousands of years.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <p class="prose" style="margin-top: var(--gap)">The consensus, supported by both genetics and archaeology, is the first: H1 entered the North African maternal gene pool through female-mediated migration from Iberia in the Neolithic (<a href="https://doi.org/10.1073/pnas.1800851115">Fregel et al. 2018</a>), a picture the <a href="research/neolithic-iberia-morocco-2023.html">2023 ancient-DNA follow-up</a> reinforces. Not a conquest — a slow mixing, in which farming women joined communities already there.</p>
+            </div>
+        </section>
+
+        <!-- Limits -->
+        <section class="band band--sand band--tight" aria-labelledby="limits">
+            <div class="container">
+                <div class="note" style="background: transparent; border-left-color: var(--ink)">
+                    <h2 id="limits" class="mt-0">What this does not show</h2>
+                    <p>These are two lines out of more than a thousand ancestral lines converging on any one person. A Y-chromosome and a mitochondrion each trace a single unbroken thread and are silent about everyone else.</p>
+                    <p class="mb-0">A haplogroup is not an ethnicity, not a nationality, and not a percentage of anything. The date ranges here are wide because the evidence is genuinely uncertain. <a href="limitations.html">The limitations page sets out the boundaries in full</a>.</p>
+                </div>
+            </div>
+        </section>
+
+        <hr class="stripe">
+
+        <!-- Sources -->
+        <section class="band band--tight" aria-labelledby="sources">
+            <div class="container">
+                <h2 id="sources" class="mt-0">Sources</h2>
+                <div class="prose">
+                    <ul>
+                        <li>Solé-Morata et al. (2017), <em>Whole Y-chromosome sequences reveal an extremely recent origin of the most common North African paternal lineage E-M183 (M81)</em>. <a href="https://doi.org/10.1038/s41598-017-16271-y">doi:10.1038/s41598-017-16271-y</a></li>
+                        <li>Ottoni et al. (2010), <em>Mitochondrial Haplogroup H1 in North Africa: An Early Holocene Arrival from Iberia</em>. <a href="https://doi.org/10.1371/journal.pone.0013378">doi:10.1371/journal.pone.0013378</a></li>
+                        <li>Fregel et al. (2018), <em>Ancient genomes from North Africa evidence prehistoric migrations to the Maghreb from both the Levant and Europe</em>. <a href="https://doi.org/10.1073/pnas.1800851115">doi:10.1073/pnas.1800851115</a></li>
+                        <li>E-PF2546 branch ages and regional frequencies: <a href="https://discover.familytreedna.com/y-dna/E-PF2546/">FamilyTreeDNA Discover</a> and <a href="https://www.yfull.com/tree/E-PF2546/">YFull</a>.</li>
+                    </ul>
+                    <p class="sourcing-note">All twelve papers summarised on this site are listed on the <a href="research.html">research page</a>. Tribal and ethnographic detail about the Aït Moussa comes from regional ethnography rather than genetics, and is flagged as such on the <a href="culture.html">culture page</a>.</p>
+                </div>
+                <p class="page-updated">Last updated: 7 September 2026</p>
+            </div>
+        </section>
+
     </main>
 
-    <footer role="contentinfo">
-        <p>&copy; 2026 North African Amazigh Heritage Project | Preserving Chtouka heritage of the Souss-Massa</p>
-        <nav class="footer-nav" aria-label="Secondary navigation">
-            <a href="start-here.html">Start Here</a>
-            <a href="glossary.html">Glossary</a>
-            <a href="limitations.html">Limitations</a>
-            <a href="maps-sites.html">Maps &amp; Sites</a>
-            <a href="contact.html">Contact</a>
-        </nav>
+    <hr class="stripe">
+
+    <footer class="site-footer" role="contentinfo">
+        <div class="container">
+            <div class="site-footer__grid">
+                <div>
+                    <h2>The research</h2>
+                    <ul>
+                        <li><a href="lineage.html">The two lines</a></li>
+                        <li><a href="genetics.html">DNA and haplogroups</a></li>
+                        <li><a href="research.html">Papers and sources</a></li>
+                        <li><a href="limitations.html">What this cannot show</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h2>Place and people</h2>
+                    <ul>
+                        <li><a href="culture.html">Culture and language</a></li>
+                        <li><a href="maps-sites.html">Maps and sites</a></li>
+                        <li><a href="glossary.html">Glossary</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h2>About</h2>
+                    <ul>
+                        <li><a href="start-here.html">Start here</a></li>
+                        <li><a href="contact.html">Contact</a></li>
+                    </ul>
+                </div>
+            </div>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+        </div>
     </footer>
-
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const chartFont = {
-                family: 'Archivo',
-                size: 14
-            };
-
-            // Admixture Chart
-            const admixtureCtx = document.getElementById('admixtureChart');
-            if (admixtureCtx) {
-                new Chart(admixtureCtx, {
-                    type: 'bar',
-                    data: {
-                        labels: ['Indigenous North African', 'Eurasian (European & Middle Eastern)'],
-                        datasets: [
-                            {
-                                label: 'Paternal (Y-DNA)',
-                                data: [75, 25],
-                                backgroundColor: '#E2A36B',
-                                borderColor: '#8B4513',
-                                borderWidth: 1,
-                                barPercentage: 0.7,
-                                categoryPercentage: 0.6
-                            },
-                            {
-                                label: 'Maternal (mtDNA)',
-                                data: [55, 45],
-                                backgroundColor: '#8B4513',
-                                borderColor: '#3E2723',
-                                borderWidth: 1,
-                                barPercentage: 0.7,
-                                categoryPercentage: 0.6
-                            }
-                        ]
-                    },
-                    options: {
-                        responsive: true,
-                        maintainAspectRatio: false,
-                        indexAxis: 'y',
-                        scales: {
-                            x: {
-                                stacked: true,
-                                title: {
-                                    display: true,
-                                    text: 'Percentage of Lineages (%)',
-                                    font: chartFont
-                                },
-                                ticks: {
-                                    font: chartFont
-                                }
-                            },
-                            y: {
-                                stacked: true,
-                                ticks: {
-                                    font: chartFont
-                                }
-                            }
-                        },
-                        plugins: {
-                            legend: {
-                                position: 'bottom',
-                                labels: {
-                                    font: chartFont,
-                                    padding: 20
-                                }
-                            },
-                            tooltip: {
-                                callbacks: {
-                                    label: function(context) {
-                                        return context.dataset.label + ': ' + context.parsed.x + '%';
-                                    }
-                                }
-                            }
-                        }
-                    }
-                });
-            }
-        });
-    </script>
 </body>
 </html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,7 +6,7 @@
   <!-- Homepage -->
   <url>
     <loc>https://northafricanorigins.com/</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
     <image:image>
@@ -45,7 +45,7 @@
   <!-- Complete Lineage Analysis -->
   <url>
     <loc>https://northafricanorigins.com/lineage.html</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
     <image:image>


### PR DESCRIPTION
Closes #77

This is the **pilot** — the design system plus two pages, so the direction can be judged before it touches the other 21.

## The diagnosis

The site read as a journal paper for three compounding reasons: one hue (warm brown) on every surface, a reading serif at every size, and a uniform grid of equal cards. `DESIGN.md` had already predicted this failure in its own text — it warned that constraining a whole site to one hue "is itself the most recognisable machine-generated look."

## The palette

Built on the **Amazigh flag** — sea blue, mountain green, sand yellow, and the red of the yaz (ⵣ). These are the colours the subject of the site already uses to identify itself, which is why the palette can afford to be loud: it is not a mood, it is a flag. Retiring the old "no blue" rule is what made this available, and it replaces a generic scheme with a specific one.

| Role | Token | White on it | As text on paper |
|---|---|---|---|
| Sea | `#1746C4` | 7.75:1 | 7.56:1 |
| Mountain | `#0B7A41` | 5.42:1 | 5.29:1 |
| Yaz | `#D11810` | 5.46:1 | 5.32:1 |
| Sand | `#FFC61E` | ✗ 1.63:1 | ✗ 1.54:1 — **fill only, carries ink** (11.77:1) |
| Ink on paper | `#16130F` on `#FFFCF5` | — | 18.07:1 |

Sea, mountain and yaz are **dual-role**: each clears AA both as white-on-colour and as colour-on-paper, so one token fills a block and sets a link. That removes the old system's central awkwardness, where no brand colour could legally carry text and every colour needed a second "text-safe" twin.

## Type and form

Bricolage Grotesque for display, Instrument Sans for reading, IBM Plex Mono for haplogroup notation, Noto Sans Tifinagh (subset to a single glyph, under 5 KB) for the yaz. Flat, hard-edged, deliberately unequal: no shadows, no gradients except the one ornament, `border-radius: 0` everywhere but legend dots.

The ornament is a band of irregular stripes taken from the striated `haik` and `tahaikt` textiles woven by Ait Moussa women — whose patterns are, unusually among Amazigh weaving traditions, purely decorative rather than protective. An openly ornamental ornament seemed the right one for this site to borrow.

## Shorter pages, same evidence

`lineage.html` goes from roughly 2,100 words of prose to **824**. Nothing was achieved by deleting qualifications — every date range, hedge and DOI survives. The cutting came from moving the argument into three authored diagrams:

- a **vertical deep-time timeline** (father's line as squares on the left, mother's as circles on the right — shape and side, not just colour)
- an **E-PF2546 frequency chart** by region
- a **scored table of the five competing explanations** for how a European maternal line reached North Africa, which replaces several hundred words of comparative prose

`DESIGN.md`'s concision rule was made precise rather than fudged: ~900 words of *running prose*, with tables, captions and source lists counted separately, plus an explicit warning not to game it by tabulating things nobody would naturally tabulate.

## Imagery

No photographs on the migrated pages. The site's images were generated under a Stable Diffusion subscription that has lapsed, so the library cannot be extended or matched. Authored inline SVG costs a few kilobytes, inherits the palette tokens, stays editable forever, and does not imply a documentary authority it has not earned.

## Two citation errors found and fixed

While writing, I linked two claims to on-site summaries that turned out to be different papers:

- "Ottoni et al. 2010" pointed at `north-africa-maternal-diversity-2026.html`, which is **Boumajdi et al. 2026**
- "Fregel et al. 2018" pointed at `neolithic-iberia-morocco-2023.html`, which is a **2023 Nature paper**

Both now cite their DOIs directly, with the on-site pages linked separately under their real names. A Guanche ancient-DNA assignment is also now attributed to public ancient-DNA datasets rather than implying a peer-reviewed source.

## Verification

- **Lighthouse (mobile, navigation):** both pages score **Accessibility 100, Best Practices 100, SEO 100 — 0 failed audits** (52 passed on the homepage, 55 on `lineage.html`).
- **Contrast:** a scripted audit walks every *HTML* text node on both pages, resolves the first opaque ancestor background, and checks the real computed pair against AA (accounting for large-text thresholds). **0 failures on both pages.** Note this reads `getComputedStyle().color`, so SVG `<text>` — which takes its colour from `fill` — is not covered by that run; the five fills used in the diagrams were checked by hand against the token table above and all clear AA.
- **320px reflow:** measured in an iframe at a true 320px layout viewport, because headless Chrome clamps its own viewport to 500px and makes narrow screenshots misleading. `scrollWidth == clientWidth == 320` on both pages. The only overflowing elements are inside `.figure__frame`, which scrolls its diagrams by design.
- **Spec conformance:** grep-verified that the shipped CSS matches `DESIGN.md` — no `box-shadow`, one gradient (the stripe), one `border-radius` (legend dots), 48px touch targets, every `ⵣ` inside a Noto-resolving class, and no colour literals anywhere including inline SVG `fill`/`stroke` (white is now `--on-colour`; the only hex values in the stylesheet are the nine token definitions).
- Rendered and reviewed at 1280px and 320px.

## One decision that is yours, not mine

I renamed the site in these two pages: **North African Amazigh Heritage → North African Origins**, in the `<title>`, the brand header, `og:site_name` and the footer. That is a brand decision that rode in on a design pilot, and you did not ask for it. It also breaks a structural rule in the same spec — the brand is supposed to be identical on every page — so as it stands two pages carry one name and 21 carry the other.

Say the word either way: I revert to `North African Amazigh Heritage`, or I keep `North African Origins` and roll it across the whole site in PR 2. Nothing else in the pilot depends on which you pick.

## Not done here

The other 9 top-level pages, the 12 research articles, a site-wide IA pass and a dark theme are follow-ups. Until then the site is visually split — migrated pages load `css/main.css`, the rest keep `css/styles.css`, and no page loads both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgzHfiCZNyLRBh9dbL9xDn