### PR TITLE
feat(research): show exact publication dates and emphasise the journal

### DIFF
--- a/changelog/unreleased/feat-exact-paper-publication-dates.md
+++ b/changelog/unreleased/feat-exact-paper-publication-dates.md
@@ -1,0 +1,8 @@
+### Added
+- Exact publication dates on all eleven papers — day, month and year, taken from each paper's Crossref record — under the year on `research.html` and in each article's kicker, marked up as `<time datetime>`. JSON-LD `datePublished` now carries the full ISO date rather than the year alone. The dates are first online publication; `research.html` says so, since print issues follow weeks later (#86)
+
+### Changed
+- The journal name on `research.html` is set in ink instead of quiet grey. It was always there, just easy to miss (#86)
+
+### Fixed
+- `research.html` said "newest first" but was only ordered by year: within 2024 and 2025 the papers were out of order, which visible exact dates would have exposed. The list is now sorted by date (#86)

--- a/css/main.css
+++ b/css/main.css
@@ -1086,6 +1086,28 @@ select:focus-visible {
     color: var(--sea);
 }
 
+/* Year and exact date share one grid cell: side by side on phones, stacked
+   in the 7rem column from 800px. The date is first online publication. */
+.paper__when {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0 0.75rem;
+}
+
+@media (min-width: 800px) {
+    .paper__when { flex-direction: column; gap: 0.1rem; }
+}
+
+.paper__date {
+    font-family: var(--font-mono);
+    font-size: var(--t-xs);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--ink);
+    white-space: nowrap;
+}
+
 .paper__title {
     font-family: var(--font-display);
     font-weight: 800;
@@ -1108,6 +1130,14 @@ select:focus-visible {
     font-size: var(--t-xs);
     letter-spacing: 0.04em;
     color: var(--ink-quiet);
+}
+
+/* The journal was here all along in quiet grey and read as noise; in ink it
+   is the second thing the eye finds after the title. */
+.paper__journal {
+    font-style: normal;
+    font-weight: 600;
+    color: var(--ink);
 }
 
 /* A figure inside a colour band: the caption cannot keep its ink-on-paper

--- a/research.html
+++ b/research.html
@@ -58,7 +58,7 @@
       "name": "Research and sources | Eleven papers",
       "url": "https://northafricanorigins.com/research.html",
       "inLanguage": "en",
-      "dateModified": "2026-09-07"
+      "dateModified": "2026-09-10"
     }
     </script>
 </head>
@@ -104,7 +104,7 @@
             <div class="container">
                 <span class="kicker">Eleven papers</span>
                 <h1 class="page-title">Research and sources</h1>
-                <p class="lead">Every population-level claim on this site traces to one of these. Each has a plain-language summary here and a DOI to the paper itself.</p>
+                <p class="lead">Every population-level claim on this site traces to one of these. Each has a plain-language summary here and a DOI to the paper itself. Dates are when each paper first appeared online, from the publisher&rsquo;s record. The print issue can follow weeks later.</p>
             </div>
         </section>
 
@@ -115,91 +115,124 @@
                 <h2 id="papers" class="mt-0">The papers, newest first</h2>
                 <ul class="papers">
                     <li class="paper">
-                        <span class="paper__year">2026</span>
+                        <div class="paper__when">
+                            <span class="paper__year">2026</span>
+                            <time class="paper__date" datetime="2026-03-26">26 March</time>
+                        </div>
                         <div>
                             <h3 class="paper__title"><a href="research/mediterranean-islamic-dna-ibiza-2026.html">Islamic-period Ibiza reveals North African gene flow</a></h3>
                             <p class="paper__finding">Genomes from medieval Ibiza burials (950–1150 CE) show North African ancestry arriving during the Umayyad and Almoravid periods — movement across the western Mediterranean running north, not south.</p>
-                            <p class="paper__meta">Rodríguez-Varela et al. &middot; Nature Communications &middot; <a href="https://doi.org/10.1038/s41467-026-70615-9">doi:10.1038/s41467-026-70615-9</a></p>
+                            <p class="paper__meta">Rodríguez-Varela et al. &middot; <cite class="paper__journal">Nature Communications</cite> &middot; <a href="https://doi.org/10.1038/s41467-026-70615-9">doi:10.1038/s41467-026-70615-9</a></p>
                         </div>
                     </li>
                     <li class="paper">
-                        <span class="paper__year">2026</span>
+                        <div class="paper__when">
+                            <span class="paper__year">2026</span>
+                            <time class="paper__date" datetime="2026-03-12">12 March</time>
+                        </div>
                         <div>
                             <h3 class="paper__title"><a href="research/north-africa-maternal-diversity-2026.html">North African maternal diversity, from 869 mitogenomes</a></h3>
                             <p class="paper__finding">A cohesive Maghreb maternal core, overlaid by historical female-mediated migrations. Directly relevant to how a lineage like H1 sits in the region.</p>
-                            <p class="paper__meta">Boumajdi et al. &middot; Mammalian Genome &middot; <a href="https://doi.org/10.1007/s00335-026-10209-4">doi:10.1007/s00335-026-10209-4</a></p>
+                            <p class="paper__meta">Boumajdi et al. &middot; <cite class="paper__journal">Mammalian Genome</cite> &middot; <a href="https://doi.org/10.1007/s00335-026-10209-4">doi:10.1007/s00335-026-10209-4</a></p>
                         </div>
                     </li>
                     <li class="paper">
-                        <span class="paper__year">2025</span>
-                        <div>
-                            <h3 class="paper__title"><a href="research/green-sahara-ancient-dna-2025.html">Ancient DNA from the Green Sahara</a></h3>
-                            <p class="paper__finding">Genomes from Takarkori in Libya, around 7,000 years ago, reveal a deeply divergent North African lineage that had been largely isolated — from a period when the Sahara was grassland.</p>
-                            <p class="paper__meta">Salem et al. &middot; Nature &middot; <a href="https://doi.org/10.1038/s41586-025-08793-7">doi:10.1038/s41586-025-08793-7</a></p>
+                        <div class="paper__when">
+                            <span class="paper__year">2025</span>
+                            <time class="paper__date" datetime="2025-07-25">25 July</time>
                         </div>
-                    </li>
-                    <li class="paper">
-                        <span class="paper__year">2025</span>
-                        <div>
-                            <h3 class="paper__title"><a href="research/eastern-maghreb-neolithic-continuity-2025.html">The eastern Maghreb kept its foragers</a></h3>
-                            <p class="paper__finding">Ancient DNA from Algeria and Tunisia shows strong continuity of local forager ancestry through the Neolithic transition — farming arrived without replacing the people.</p>
-                            <p class="paper__meta">Lipson et al. &middot; Nature &middot; <a href="https://doi.org/10.1038/s41586-025-08699-4">doi:10.1038/s41586-025-08699-4</a></p>
-                        </div>
-                    </li>
-                    <li class="paper">
-                        <span class="paper__year">2025</span>
-                        <div>
-                            <h3 class="paper__title"><a href="research/punic-genetic-diversity-2025.html">Punic people were genetically diverse, and barely Levantine</a></h3>
-                            <p class="paper__finding">Genome-wide data from 210 individuals finds Carthaginian-era populations dominated by local and Mediterranean ancestry, with almost no Levantine contribution — culture spread without much migration.</p>
-                            <p class="paper__meta">Reich et al. &middot; Nature &middot; <a href="https://doi.org/10.1038/s41586-025-08913-3">doi:10.1038/s41586-025-08913-3</a></p>
-                        </div>
-                    </li>
-                    <li class="paper">
-                        <span class="paper__year">2025</span>
-                        <div>
-                            <h3 class="paper__title"><a href="research/canary-islands-amazigh-history-2025.html">The Guanches before European contact</a></h3>
-                            <p class="paper__finding">Demographic history of the indigenous Canarian Amazigh, whose ancestors sailed from North Africa. The same paternal branch as this lineage has been reported among them.</p>
-                            <p class="paper__meta">Santana et al. &middot; Scientific Reports &middot; <a href="https://doi.org/10.1038/s41598-025-04302-y">doi:10.1038/s41598-025-04302-y</a></p>
-                        </div>
-                    </li>
-                    <li class="paper">
-                        <span class="paper__year">2025</span>
                         <div>
                             <h3 class="paper__title"><a href="research/north-african-mitogenomes-2025.html">733 modern and 43 ancient mitogenomes</a></h3>
                             <p class="paper__finding">A large survey of North African maternal lineages, including the H1 subclade patterns that underlie the maternal half of this lineage.</p>
-                            <p class="paper__meta">Colombo et al. &middot; Scientific Reports &middot; <a href="https://doi.org/10.1038/s41598-025-12209-x">doi:10.1038/s41598-025-12209-x</a></p>
+                            <p class="paper__meta">Colombo et al. &middot; <cite class="paper__journal">Scientific Reports</cite> &middot; <a href="https://doi.org/10.1038/s41598-025-12209-x">doi:10.1038/s41598-025-12209-x</a></p>
                         </div>
                     </li>
                     <li class="paper">
-                        <span class="paper__year">2024</span>
+                        <div class="paper__when">
+                            <span class="paper__year">2025</span>
+                            <time class="paper__date" datetime="2025-06-03">3 June</time>
+                        </div>
                         <div>
-                            <h3 class="paper__title"><a href="research/amazigh-genomic-heterogeneity-2024.html">Amazigh genomic heterogeneity, village by village</a></h3>
-                            <p class="paper__finding">The largest Amazigh genomic dataset to date finds diversity at a microgeographical scale, two trans-Saharan admixture waves, and deep Epipaleolithic roots.</p>
-                            <p class="paper__meta">Vilà-Valls et al. &middot; Scientific Reports &middot; <a href="https://doi.org/10.1038/s41598-024-60568-8">doi:10.1038/s41598-024-60568-8</a></p>
+                            <h3 class="paper__title"><a href="research/canary-islands-amazigh-history-2025.html">The Guanches before European contact</a></h3>
+                            <p class="paper__finding">Demographic history of the indigenous Canarian Amazigh, whose ancestors sailed from North Africa. The same paternal branch as this lineage has been reported among them.</p>
+                            <p class="paper__meta">Santana et al. &middot; <cite class="paper__journal">Scientific Reports</cite> &middot; <a href="https://doi.org/10.1038/s41598-025-04302-y">doi:10.1038/s41598-025-04302-y</a></p>
                         </div>
                     </li>
                     <li class="paper">
-                        <span class="paper__year">2024</span>
+                        <div class="paper__when">
+                            <span class="paper__year">2025</span>
+                            <time class="paper__date" datetime="2025-04-23">23 April</time>
+                        </div>
+                        <div>
+                            <h3 class="paper__title"><a href="research/punic-genetic-diversity-2025.html">Punic people were genetically diverse, and barely Levantine</a></h3>
+                            <p class="paper__finding">Genome-wide data from 210 individuals finds Carthaginian-era populations dominated by local and Mediterranean ancestry, with almost no Levantine contribution — culture spread without much migration.</p>
+                            <p class="paper__meta">Reich et al. &middot; <cite class="paper__journal">Nature</cite> &middot; <a href="https://doi.org/10.1038/s41586-025-08913-3">doi:10.1038/s41586-025-08913-3</a></p>
+                        </div>
+                    </li>
+                    <li class="paper">
+                        <div class="paper__when">
+                            <span class="paper__year">2025</span>
+                            <time class="paper__date" datetime="2025-04-02">2 April</time>
+                        </div>
+                        <div>
+                            <h3 class="paper__title"><a href="research/green-sahara-ancient-dna-2025.html">Ancient DNA from the Green Sahara</a></h3>
+                            <p class="paper__finding">Genomes from Takarkori in Libya, around 7,000 years ago, reveal a deeply divergent North African lineage that had been largely isolated — from a period when the Sahara was grassland.</p>
+                            <p class="paper__meta">Salem et al. &middot; <cite class="paper__journal">Nature</cite> &middot; <a href="https://doi.org/10.1038/s41586-025-08793-7">doi:10.1038/s41586-025-08793-7</a></p>
+                        </div>
+                    </li>
+                    <li class="paper">
+                        <div class="paper__when">
+                            <span class="paper__year">2025</span>
+                            <time class="paper__date" datetime="2025-03-12">12 March</time>
+                        </div>
+                        <div>
+                            <h3 class="paper__title"><a href="research/eastern-maghreb-neolithic-continuity-2025.html">The eastern Maghreb kept its foragers</a></h3>
+                            <p class="paper__finding">Ancient DNA from Algeria and Tunisia shows strong continuity of local forager ancestry through the Neolithic transition — farming arrived without replacing the people.</p>
+                            <p class="paper__meta">Lipson et al. &middot; <cite class="paper__journal">Nature</cite> &middot; <a href="https://doi.org/10.1038/s41586-025-08699-4">doi:10.1038/s41586-025-08699-4</a></p>
+                        </div>
+                    </li>
+                    <li class="paper">
+                        <div class="paper__when">
+                            <span class="paper__year">2024</span>
+                            <time class="paper__date" datetime="2024-07-30">30 July</time>
+                        </div>
                         <div>
                             <h3 class="paper__title"><a href="research/north-africa-demographic-history-2024.html">Amazigh and Arab populations diverged over 20,000 years ago</a></h3>
                             <p class="paper__finding">Whole-genome demographic modelling separates deep Epipaleolithic Amazigh origins from much later Arabization gene flow, via a soft-split model.</p>
-                            <p class="paper__meta">Serradell et al. &middot; Genome Biology &middot; <a href="https://doi.org/10.1186/s13059-024-03341-4">doi:10.1186/s13059-024-03341-4</a></p>
+                            <p class="paper__meta">Serradell et al. &middot; <cite class="paper__journal">Genome Biology</cite> &middot; <a href="https://doi.org/10.1186/s13059-024-03341-4">doi:10.1186/s13059-024-03341-4</a></p>
                         </div>
                     </li>
                     <li class="paper">
-                        <span class="paper__year">2023</span>
+                        <div class="paper__when">
+                            <span class="paper__year">2024</span>
+                            <time class="paper__date" datetime="2024-05-01">1 May</time>
+                        </div>
+                        <div>
+                            <h3 class="paper__title"><a href="research/amazigh-genomic-heterogeneity-2024.html">Amazigh genomic heterogeneity, village by village</a></h3>
+                            <p class="paper__finding">The largest Amazigh genomic dataset to date finds diversity at a microgeographical scale, two trans-Saharan admixture waves, and deep Epipaleolithic roots.</p>
+                            <p class="paper__meta">Vilà-Valls et al. &middot; <cite class="paper__journal">Scientific Reports</cite> &middot; <a href="https://doi.org/10.1038/s41598-024-60568-8">doi:10.1038/s41598-024-60568-8</a></p>
+                        </div>
+                    </li>
+                    <li class="paper">
+                        <div class="paper__when">
+                            <span class="paper__year">2023</span>
+                            <time class="paper__date" datetime="2023-06-07">7 June</time>
+                        </div>
                         <div>
                             <h3 class="paper__title"><a href="research/neolithic-iberia-morocco-2023.html">The Maghreb Neolithic began with migrants from Iberia</a></h3>
                             <p class="paper__finding">Ancient DNA from Neolithic Morocco confirms migration across the Strait of Gibraltar — the ancient-DNA reinforcement of the scenario that best explains this maternal line.</p>
-                            <p class="paper__meta">Villalba-Mouco et al. &middot; Nature &middot; <a href="https://doi.org/10.1038/s41586-023-06166-6">doi:10.1038/s41586-023-06166-6</a></p>
+                            <p class="paper__meta">Villalba-Mouco et al. &middot; <cite class="paper__journal">Nature</cite> &middot; <a href="https://doi.org/10.1038/s41586-023-06166-6">doi:10.1038/s41586-023-06166-6</a></p>
                         </div>
                     </li>
                     <li class="paper">
-                        <span class="paper__year">2017</span>
+                        <div class="paper__when">
+                            <span class="paper__year">2017</span>
+                            <time class="paper__date" datetime="2017-11-21">21 November</time>
+                        </div>
                         <div>
                             <h3 class="paper__title"><a href="research/e-m183-recent-origin-2018.html">E-M81 is far younger than anyone expected</a></h3>
                             <p class="paper__finding">Whole Y-chromosome sequencing dates the defining Amazigh paternal marker to roughly 2,000–3,000 years ago, with a star-like pattern indicating rapid expansion from a small founder group.</p>
-                            <p class="paper__meta">Solé-Morata et al. &middot; Scientific Reports &middot; <a href="https://doi.org/10.1038/s41598-017-16271-y">doi:10.1038/s41598-017-16271-y</a></p>
+                            <p class="paper__meta">Solé-Morata et al. &middot; <cite class="paper__journal">Scientific Reports</cite> &middot; <a href="https://doi.org/10.1038/s41598-017-16271-y">doi:10.1038/s41598-017-16271-y</a></p>
                         </div>
                     </li>
                 </ul>
@@ -218,7 +251,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated">Last updated: 10 September 2026</p>
             </div>
         </section>
 

--- a/research/amazigh-genomic-heterogeneity-2024.html
+++ b/research/amazigh-genomic-heterogeneity-2024.html
@@ -57,8 +57,8 @@
       "headline": "Understanding the Genomic Heterogeneity of North African Imazighen: From Broad to Microgeographical Perspectives",
       "url": "https://northafricanorigins.com/research/amazigh-genomic-heterogeneity-2024.html",
       "inLanguage": "en",
-      "datePublished": "2024",
-      "dateModified": "2026-09-07",
+      "datePublished": "2024-05-01",
+      "dateModified": "2026-09-10",
       "sameAs": "https://doi.org/10.1038/s41598-024-60568-8"
     }
     </script>
@@ -103,7 +103,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <span class="kicker">2024 &middot; Scientific Reports</span>
+                <span class="kicker"><time datetime="2024-05-01">1 May 2024</time> &middot; Scientific Reports</span>
                 <h1 class="page-title">Understanding the Genomic Heterogeneity of North African Imazighen: From Broad to Microgeographical Perspectives</h1>
                 <p class="page-updated">Vilà-Valls et al. &middot; <a href="https://doi.org/10.1038/s41598-024-60568-8">doi:10.1038/s41598-024-60568-8</a></p>
             </div>
@@ -161,7 +161,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated">Last updated: 10 September 2026</p>
             </div>
         </section>
 

--- a/research/canary-islands-amazigh-history-2025.html
+++ b/research/canary-islands-amazigh-history-2025.html
@@ -57,8 +57,8 @@
       "headline": "Climate, Biogeography, and Human Resilience in the Demographic History of the Canary Islands During the Amazigh Period",
       "url": "https://northafricanorigins.com/research/canary-islands-amazigh-history-2025.html",
       "inLanguage": "en",
-      "datePublished": "2025",
-      "dateModified": "2026-09-07",
+      "datePublished": "2025-06-03",
+      "dateModified": "2026-09-10",
       "sameAs": "https://doi.org/10.1038/s41598-025-04302-y"
     }
     </script>
@@ -103,7 +103,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <span class="kicker">2025 &middot; Scientific Reports</span>
+                <span class="kicker"><time datetime="2025-06-03">3 June 2025</time> &middot; Scientific Reports</span>
                 <h1 class="page-title">Climate, Biogeography, and Human Resilience in the Demographic History of the Canary Islands During the Amazigh Period</h1>
                 <p class="page-updated">Santana et al. &middot; <a href="https://doi.org/10.1038/s41598-025-04302-y">doi:10.1038/s41598-025-04302-y</a></p>
             </div>
@@ -156,7 +156,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated">Last updated: 10 September 2026</p>
             </div>
         </section>
 

--- a/research/e-m183-recent-origin-2018.html
+++ b/research/e-m183-recent-origin-2018.html
@@ -57,8 +57,8 @@
       "headline": "Whole Y-Chromosome Sequences Reveal an Extremely Recent Origin of E-M183",
       "url": "https://northafricanorigins.com/research/e-m183-recent-origin-2018.html",
       "inLanguage": "en",
-      "datePublished": "2017",
-      "dateModified": "2026-09-07",
+      "datePublished": "2017-11-21",
+      "dateModified": "2026-09-10",
       "sameAs": "https://doi.org/10.1038/s41598-017-16271-y"
     }
     </script>
@@ -103,7 +103,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <span class="kicker">2017 &middot; Scientific Reports</span>
+                <span class="kicker"><time datetime="2017-11-21">21 November 2017</time> &middot; Scientific Reports</span>
                 <h1 class="page-title">Whole Y-Chromosome Sequences Reveal an Extremely Recent Origin of E-M183</h1>
                 <p class="page-updated">Solé-Morata et al. &middot; <a href="https://doi.org/10.1038/s41598-017-16271-y">doi:10.1038/s41598-017-16271-y</a></p>
             </div>
@@ -160,7 +160,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated">Last updated: 10 September 2026</p>
             </div>
         </section>
 

--- a/research/eastern-maghreb-neolithic-continuity-2025.html
+++ b/research/eastern-maghreb-neolithic-continuity-2025.html
@@ -57,8 +57,8 @@
       "headline": "High Continuity of Forager Ancestry in the Neolithic Period of the Eastern Maghreb",
       "url": "https://northafricanorigins.com/research/eastern-maghreb-neolithic-continuity-2025.html",
       "inLanguage": "en",
-      "datePublished": "2025",
-      "dateModified": "2026-09-07",
+      "datePublished": "2025-03-12",
+      "dateModified": "2026-09-10",
       "sameAs": "https://doi.org/10.1038/s41586-025-08699-4"
     }
     </script>
@@ -103,7 +103,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <span class="kicker">2025 &middot; Nature</span>
+                <span class="kicker"><time datetime="2025-03-12">12 March 2025</time> &middot; Nature</span>
                 <h1 class="page-title">High Continuity of Forager Ancestry in the Neolithic Period of the Eastern Maghreb</h1>
                 <p class="page-updated">Lipson et al. &middot; <a href="https://doi.org/10.1038/s41586-025-08699-4">doi:10.1038/s41586-025-08699-4</a></p>
             </div>
@@ -159,7 +159,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated">Last updated: 10 September 2026</p>
             </div>
         </section>
 

--- a/research/green-sahara-ancient-dna-2025.html
+++ b/research/green-sahara-ancient-dna-2025.html
@@ -57,8 +57,8 @@
       "headline": "Ancient DNA from the Green Sahara Reveals Ancestral North African Lineage",
       "url": "https://northafricanorigins.com/research/green-sahara-ancient-dna-2025.html",
       "inLanguage": "en",
-      "datePublished": "2025",
-      "dateModified": "2026-09-07",
+      "datePublished": "2025-04-02",
+      "dateModified": "2026-09-10",
       "sameAs": "https://doi.org/10.1038/s41586-025-08793-7"
     }
     </script>
@@ -103,7 +103,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <span class="kicker">2025 &middot; Nature</span>
+                <span class="kicker"><time datetime="2025-04-02">2 April 2025</time> &middot; Nature</span>
                 <h1 class="page-title">Ancient DNA from the Green Sahara Reveals Ancestral North African Lineage</h1>
                 <p class="page-updated">Salem et al. &middot; <a href="https://doi.org/10.1038/s41586-025-08793-7">doi:10.1038/s41586-025-08793-7</a></p>
             </div>
@@ -160,7 +160,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated">Last updated: 10 September 2026</p>
             </div>
         </section>
 

--- a/research/mediterranean-islamic-dna-ibiza-2026.html
+++ b/research/mediterranean-islamic-dna-ibiza-2026.html
@@ -57,8 +57,8 @@
       "headline": "Analysis of Medieval Burials from Ibiza Reveals Genetic and Pathogenic Diversity During the Islamic Period",
       "url": "https://northafricanorigins.com/research/mediterranean-islamic-dna-ibiza-2026.html",
       "inLanguage": "en",
-      "datePublished": "2026",
-      "dateModified": "2026-09-07",
+      "datePublished": "2026-03-26",
+      "dateModified": "2026-09-10",
       "sameAs": "https://doi.org/10.1038/s41467-026-70615-9"
     }
     </script>
@@ -103,7 +103,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <span class="kicker">2026 &middot; Nature Communications</span>
+                <span class="kicker"><time datetime="2026-03-26">26 March 2026</time> &middot; Nature Communications</span>
                 <h1 class="page-title">Analysis of Medieval Burials from Ibiza Reveals Genetic and Pathogenic Diversity During the Islamic Period</h1>
                 <p class="page-updated">Rodríguez-Varela et al. &middot; <a href="https://doi.org/10.1038/s41467-026-70615-9">doi:10.1038/s41467-026-70615-9</a></p>
             </div>
@@ -158,7 +158,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated">Last updated: 10 September 2026</p>
             </div>
         </section>
 

--- a/research/neolithic-iberia-morocco-2023.html
+++ b/research/neolithic-iberia-morocco-2023.html
@@ -57,8 +57,8 @@
       "headline": "Northwest African Neolithic Initiated by Migrants from Iberia and Levant",
       "url": "https://northafricanorigins.com/research/neolithic-iberia-morocco-2023.html",
       "inLanguage": "en",
-      "datePublished": "2023",
-      "dateModified": "2026-09-07",
+      "datePublished": "2023-06-07",
+      "dateModified": "2026-09-10",
       "sameAs": "https://doi.org/10.1038/s41586-023-06166-6"
     }
     </script>
@@ -103,7 +103,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <span class="kicker">2023 &middot; Nature</span>
+                <span class="kicker"><time datetime="2023-06-07">7 June 2023</time> &middot; Nature</span>
                 <h1 class="page-title">Northwest African Neolithic Initiated by Migrants from Iberia and Levant</h1>
                 <p class="page-updated">Villalba-Mouco et al. &middot; <a href="https://doi.org/10.1038/s41586-023-06166-6">doi:10.1038/s41586-023-06166-6</a></p>
             </div>
@@ -160,7 +160,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated">Last updated: 10 September 2026</p>
             </div>
         </section>
 

--- a/research/north-africa-demographic-history-2024.html
+++ b/research/north-africa-demographic-history-2024.html
@@ -57,8 +57,8 @@
       "headline": "Modelling the Demographic History of Human North African Genomes Points to a Recent Soft Split Divergence Between Populations",
       "url": "https://northafricanorigins.com/research/north-africa-demographic-history-2024.html",
       "inLanguage": "en",
-      "datePublished": "2024",
-      "dateModified": "2026-09-07",
+      "datePublished": "2024-07-30",
+      "dateModified": "2026-09-10",
       "sameAs": "https://doi.org/10.1186/s13059-024-03341-4"
     }
     </script>
@@ -103,7 +103,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <span class="kicker">2024 &middot; Genome Biology</span>
+                <span class="kicker"><time datetime="2024-07-30">30 July 2024</time> &middot; Genome Biology</span>
                 <h1 class="page-title">Modelling the Demographic History of Human North African Genomes Points to a Recent Soft Split Divergence Between Populations</h1>
                 <p class="page-updated">Serradell et al. &middot; <a href="https://doi.org/10.1186/s13059-024-03341-4">doi:10.1186/s13059-024-03341-4</a></p>
             </div>
@@ -161,7 +161,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated">Last updated: 10 September 2026</p>
             </div>
         </section>
 

--- a/research/north-africa-maternal-diversity-2026.html
+++ b/research/north-africa-maternal-diversity-2026.html
@@ -57,8 +57,8 @@
       "headline": "The North African Maternal Genetic Diversity Enriched by Historical Migrations",
       "url": "https://northafricanorigins.com/research/north-africa-maternal-diversity-2026.html",
       "inLanguage": "en",
-      "datePublished": "2026",
-      "dateModified": "2026-09-07",
+      "datePublished": "2026-03-12",
+      "dateModified": "2026-09-10",
       "sameAs": "https://doi.org/10.1007/s00335-026-10209-4"
     }
     </script>
@@ -103,7 +103,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <span class="kicker">2026 &middot; Mammalian Genome</span>
+                <span class="kicker"><time datetime="2026-03-12">12 March 2026</time> &middot; Mammalian Genome</span>
                 <h1 class="page-title">The North African Maternal Genetic Diversity Enriched by Historical Migrations</h1>
                 <p class="page-updated">Boumajdi et al. &middot; <a href="https://doi.org/10.1007/s00335-026-10209-4">doi:10.1007/s00335-026-10209-4</a></p>
             </div>
@@ -159,7 +159,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated">Last updated: 10 September 2026</p>
             </div>
         </section>
 

--- a/research/north-african-mitogenomes-2025.html
+++ b/research/north-african-mitogenomes-2025.html
@@ -57,8 +57,8 @@
       "headline": "The Origin of Modern North Africans as Depicted by a Massive Survey of Mitogenomes",
       "url": "https://northafricanorigins.com/research/north-african-mitogenomes-2025.html",
       "inLanguage": "en",
-      "datePublished": "2025",
-      "dateModified": "2026-09-07",
+      "datePublished": "2025-07-25",
+      "dateModified": "2026-09-10",
       "sameAs": "https://doi.org/10.1038/s41598-025-12209-x"
     }
     </script>
@@ -103,7 +103,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <span class="kicker">2025 &middot; Scientific Reports</span>
+                <span class="kicker"><time datetime="2025-07-25">25 July 2025</time> &middot; Scientific Reports</span>
                 <h1 class="page-title">The Origin of Modern North Africans as Depicted by a Massive Survey of Mitogenomes</h1>
                 <p class="page-updated">Colombo et al. &middot; <a href="https://doi.org/10.1038/s41598-025-12209-x">doi:10.1038/s41598-025-12209-x</a></p>
             </div>
@@ -160,7 +160,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated">Last updated: 10 September 2026</p>
             </div>
         </section>
 

--- a/research/punic-genetic-diversity-2025.html
+++ b/research/punic-genetic-diversity-2025.html
@@ -57,8 +57,8 @@
       "headline": "Punic People Were Genetically Diverse with Almost No Levantine Ancestors",
       "url": "https://northafricanorigins.com/research/punic-genetic-diversity-2025.html",
       "inLanguage": "en",
-      "datePublished": "2025",
-      "dateModified": "2026-09-07",
+      "datePublished": "2025-04-23",
+      "dateModified": "2026-09-10",
       "sameAs": "https://doi.org/10.1038/s41586-025-08913-3"
     }
     </script>
@@ -103,7 +103,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <span class="kicker">2025 &middot; Nature</span>
+                <span class="kicker"><time datetime="2025-04-23">23 April 2025</time> &middot; Nature</span>
                 <h1 class="page-title">Punic People Were Genetically Diverse with Almost No Levantine Ancestors</h1>
                 <p class="page-updated">Reich et al. &middot; <a href="https://doi.org/10.1038/s41586-025-08913-3">doi:10.1038/s41586-025-08913-3</a></p>
             </div>
@@ -158,7 +158,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated">Last updated: 10 September 2026</p>
             </div>
         </section>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -89,7 +89,7 @@
   <!-- Research Blog Page -->
   <url>
     <loc>https://northafricanorigins.com/research.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -102,7 +102,7 @@
   <!-- Research Article: Green Sahara Ancient DNA -->
   <url>
     <loc>https://northafricanorigins.com/research/green-sahara-ancient-dna-2025.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -110,7 +110,7 @@
   <!-- Research Article: North African Mitogenomes -->
   <url>
     <loc>https://northafricanorigins.com/research/north-african-mitogenomes-2025.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -120,7 +120,7 @@
   <!-- Research Article: Punic Genetic Diversity -->
   <url>
     <loc>https://northafricanorigins.com/research/punic-genetic-diversity-2025.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -128,7 +128,7 @@
   <!-- Research Article: North Africa Maternal Diversity -->
   <url>
     <loc>https://northafricanorigins.com/research/north-africa-maternal-diversity-2026.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -136,7 +136,7 @@
   <!-- Research Article: Neolithic Iberia-Morocco Migration -->
   <url>
     <loc>https://northafricanorigins.com/research/neolithic-iberia-morocco-2023.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -144,7 +144,7 @@
   <!-- Research Article: E-M183 Recent Origin -->
   <url>
     <loc>https://northafricanorigins.com/research/e-m183-recent-origin-2018.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -152,7 +152,7 @@
   <!-- Research Article: North Africa Demographic History -->
   <url>
     <loc>https://northafricanorigins.com/research/north-africa-demographic-history-2024.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -160,7 +160,7 @@
   <!-- Research Article: Amazigh Genomic Heterogeneity -->
   <url>
     <loc>https://northafricanorigins.com/research/amazigh-genomic-heterogeneity-2024.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -168,7 +168,7 @@
   <!-- Research Article: Eastern Maghreb Neolithic Continuity -->
   <url>
     <loc>https://northafricanorigins.com/research/eastern-maghreb-neolithic-continuity-2025.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -197,13 +197,13 @@
   </url>
   <url>
     <loc>https://northafricanorigins.com/research/canary-islands-amazigh-history-2025.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://northafricanorigins.com/research/mediterranean-islamic-dna-ibiza-2026.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.6</priority>
   </url>


### PR DESCRIPTION
## What

The research papers showed only a year ("2026"). Each now shows its exact publication date, and the journal is easier to see.

- **`research.html`**: the exact date sits under the year (`2026` / `26 March`), marked up as `<time datetime>`. The journal name, which was always there in quiet grey mono, is now set in ink and weight 600 via `<cite class="paper__journal">`.
- **11 article pages**: the kicker goes from `2025 · Nature` to `2 April 2025 · Nature`. JSON-LD `datePublished` (a `ScholarlyArticle` with `sameAs` the DOI) now carries the full ISO date instead of the year alone.
- A sentence in the `research.html` lead says the dates are **first online publication**, from the publisher's record. Several print issues come weeks later (Green Sahara: online 2 April, print 1 May 2025), so a reader who checks would otherwise find a mismatch.
- **Ordering fix:** the list said "newest first" but was only sorted by year. Within 2024 and 2025 the papers were out of order, and visible dates would have made that obvious. It is now sorted by exact date.
- "Last updated", `dateModified` and `sitemap.xml` `lastmod` are bumped to 2026-09-10 on the 12 changed pages, as `DESIGN.md` requires. The noindex redirect stub has no date and is unchanged.

## Source of the dates

All from `api.crossref.org/works/<doi>`, using the online publication date. None is hand-typed; the edit script asserted each page's existing year and journal matched Crossref before rewriting.

| Paper | Journal | Online |
|---|---|---|
| Rodríguez-Varela et al. | Nature Communications | 2026-03-26 |
| Boumajdi et al. | Mammalian Genome | 2026-03-12 |
| Colombo et al. | Scientific Reports | 2025-07-25 |
| Santana et al. | Scientific Reports | 2025-06-03 |
| Reich et al. | Nature | 2025-04-23 |
| Salem et al. | Nature | 2025-04-02 |
| Lipson et al. | Nature | 2025-03-12 |
| Serradell et al. | Genome Biology | 2024-07-30 |
| Vilà-Valls et al. | Scientific Reports | 2024-05-01 |
| Villalba-Mouco et al. | Nature | 2023-06-07 |
| Solé-Morata et al. | Scientific Reports | 2017-11-21 |

## Verification

- Same-origin iframe harness at 320 / 390 / 1280 px: zero horizontal overflow, and no date wraps. The longest date, "21 November", is 84 px wide in the 112 px column. Year and date sit side by side on phones and stack from 800 px.
- Lighthouse (mobile), `research.html` and one article: accessibility, best practices and SEO all **100**.
- New text is `--ink` on paper (18:1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jzVgf9BHLh9818XG1N3mY
- Tokens - total: 14,920 (implementation: unavailable + git-flow: 14,920)

Closes #86