### PR TITLE
feat(home): lead with North Africa's population history, move the family case to One family

### DIFF
--- a/.github/research-scout/PROMPT.md
+++ b/.github/research-scout/PROMPT.md
@@ -1,9 +1,10 @@
 # Research scout: screening and summary instructions
 
-You are screening new peer-reviewed papers for northafricanorigins.com. The site documents one
-Amazigh (Berber) family line from the Chtouka, Souss-Massa, Morocco: paternal haplogroup
-`E-PF2546` and maternal haplogroup `H1-T16189C!`. It sets that line against the published
-population genetics of North Africa. Each paper it cites gets a plain-language summary page.
+You are screening new peer-reviewed papers for northafricanorigins.com. The site explains how
+migrations shaped North Africa's population over the last 20,000 years, from the published
+genetics. One Amazigh (Berber) family line from the Chtouka, Souss-Massa, Morocco (paternal
+haplogroup `E-PF2546`, maternal haplogroup `H1-T16189C!`) is its worked example. Each paper
+it cites gets a plain-language summary page.
 
 **Nothing you write is reviewed by a person before it goes live.** A script builds the pages from
 your output, checks the facts it can (DOI, journal, date), and merges. It cannot judge your
@@ -16,7 +17,8 @@ prose, so the rules below are the whole safeguard.
   everything you know about each paper. You have no web access, and must not use memory of
   the paper or its field to fill gaps.
 - For the site's voice and its own claims, you may read `DESIGN.md` (the Content section),
-  `lineage.html`, `limitations.html` and one existing summary, e.g.
+  `index.html` (North Africa's population history, layer by layer), `lineage.html` (the
+  family case), `limitations.html` and one existing summary, e.g.
   `research/green-sahara-ancient-dna-2025.html`.
 
 ## 1. Decide, for every candidate
@@ -59,10 +61,11 @@ Plain text only: no HTML, no Markdown, no emoji, no exclamation marks.
   them. Haplogroups exactly as the abstract writes them.
 - **No hype:** not "landmark", "groundbreaking", "rewrites history" or "first ever", unless the
   abstract makes that claim itself, and then attribute it ("the authors describe it as...").
-- **Relevance must be honest about distance.** Say plainly whether the paper bears on this
-  family line (`E-PF2546`, `H1-T16189C!`, the Chtouka, Souss-Massa) or only gives regional
-  context. Never say it tested, confirmed or dated anything about this line unless the abstract
-  names those lineages or that region. Read `lineage.html` if you need to connect it accurately.
+- **Relevance must be honest about distance.** First say where the paper fits in North Africa's
+  population history, the layered story on `index.html`. Then say plainly whether it bears on
+  the family case (`E-PF2546`, `H1-T16189C!`, the Chtouka, Souss-Massa) or not. Never say it
+  tested, confirmed or dated anything about that family line unless the abstract names those
+  lineages or that region. Read `lineage.html` if you need to connect it accurately.
 
 ## 3. Output files
 

--- a/.github/research-scout/scout.py
+++ b/.github/research-scout/scout.py
@@ -64,7 +64,7 @@ PLACE = ('("North Africa" OR "North African" OR "Northwest Africa" OR Maghreb OR
 
 # The only files a scout run may change. Anything else fails validation.
 ALLOWED = re.compile(
-    r"^(research\.html|lineage\.html|sitemap\.xml|research/[a-z0-9-]+\.html"
+    r"^(research\.html|lineage\.html|index\.html|start-here\.html|sitemap\.xml|research/[a-z0-9-]+\.html"
     r"|changelog/unreleased/[a-z0-9-]+\.md|\.github/research-scout/screened\.json)$")
 
 # Hard limits on the model's prose. PROMPT.md asks for less; the margin means a run is
@@ -95,6 +95,8 @@ COUNT_PHRASES = {
     "index": [rf"\b({NUM}) papers\b", rf"\bthe ({NUM}) peer-reviewed studies\b"],
     "lineage": [rf"\bAll ({NUM}) papers summarised\b"],
     "article": [rf"\bAll ({NUM}) summaries are listed\b"],
+    "home": [r'<span class="stat__num">(\d+)</span>\s*<span class="stat__label">Peer-reviewed papers'],
+    "start": [rf"\b({NUM}) paper summaries\b"],
 }
 ITEM = re.compile(r'\n[ \t]*<li class="paper">.*?</li>', re.S)
 DOI_LINK = re.compile(r'https://doi\.org/([^"<\s]+)')
@@ -250,19 +252,27 @@ def item_fields(item: str) -> dict:
 def count_targets():
     yield INDEX, COUNT_PHRASES["index"]
     yield ROOT / "lineage.html", COUNT_PHRASES["lineage"]
+    yield ROOT / "index.html", COUNT_PHRASES["home"]
+    yield ROOT / "start-here.html", COUNT_PHRASES["start"]
     for f in sorted((ROOT / "research").glob("*.html")):
         yield f, COUNT_PHRASES["article"]
 
 
 def sync_counts(n: int) -> list[Path]:
     word = number_word(n)
+
+    def spell(found: str) -> str:  # keep the form the page already uses: 13, thirteen or Thirteen
+        if found.isdigit():
+            return str(n)
+        return word.capitalize() if found[0].isupper() else word
+
     changed = []
     for f, patterns in count_targets():
         text = f.read_text()
         new = text
         for p in patterns:
-            new = re.sub(p, lambda m: m.group(0).replace(
-                m.group(1), word.capitalize() if m.group(1)[0].isupper() else word), new, flags=re.I)
+            new = re.sub(p, lambda m: m.group(0)[:m.start(1) - m.start(0)] + spell(m.group(1))
+                         + m.group(0)[m.end(1) - m.start(0):], new, flags=re.I)
         if new != text:
             f.write_text(new)
             changed.append(f)
@@ -277,6 +287,7 @@ def bump_modified(paths, today: dt.date) -> None:
         t = re.sub(r"Last updated: \d{1,2} [A-Z][a-z]+ \d{4}", f"Last updated: {long_date(str(today))}", t)
         f.write_text(t)
         rel = f.relative_to(ROOT).as_posix()
+        rel = "" if rel == "index.html" else rel  # the homepage is listed as /
         sm = re.sub(rf"(<loc>{re.escape(SITE)}/{re.escape(rel)}</loc>\s*<lastmod>)[^<]+",
                     rf"\g<1>{today}", sm)
     SITEMAP.write_text(sm)
@@ -641,7 +652,8 @@ def cmd_validate(args) -> None:
         if f.parent.name == "research" and f.name not in pages:
             continue  # the noindex redirect stub
         text = f.read_text()
-        found = {m.group(1).lower() for p in patterns for m in re.finditer(p, text, re.I)}
+        found = {number_word(int(g)) if g.isdigit() else g.lower()
+                 for p in patterns for g in (m.group(1) for m in re.finditer(p, text, re.I))}
         rel = f.relative_to(ROOT).as_posix()
         if not found:
             errors.append(f"{rel}: the paper-count sentence is missing")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ This is a **no-build static site** — plain HTML, CSS, and vanilla JS. No packa
 
 - `index.html`, `lineage.html`, `genetics.html`, `culture.html`, `research.html`, `contact.html`,
   `start-here.html`, `glossary.html`, `maps-sites.html`, `limitations.html` — the site pages
-- `research/*.html` — twelve paper summaries
+- `research/*.html` — one summary per paper listed on `research.html` (the scout adds new ones)
 - `css/main.css` — the current design system (see `DESIGN.md`). `css/styles.css` is the legacy stylesheet still serving un-migrated pages; it is deleted when the last page moves over. A page loads one or the other, never both
 - `js/reading-aids.js` — TOC rail, reading progress, back-to-top
 - `img/` — legacy WebP imagery (plus `og-card.jpg` for social). Migrated pages use authored inline SVG diagrams instead of photographs — see the Imagery section of `DESIGN.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Static genealogy/cultural heritage website hosted on GitHub Pages documenting Amazigh (Berber) genetic lineage from Souss-Massa, Morocco. Combines genetic analysis (Y-DNA haplogroup E-PF2546, mtDNA H1-T16189C!), historical research on the Chtouka confederation, and cultural preservation.
+Static website hosted on GitHub Pages explaining how migrations shaped North Africa's population, from peer-reviewed genetics (the homepage timeline is built only from the papers summarised in `research/`). One Amazigh (Berber) family from Souss-Massa, Morocco (Y-DNA E-PF2546, mtDNA H1-T16189C!) is the worked example on the "One family" page, `lineage.html`. Also covers the history and culture of the Chtouka confederation.
 
 **Live site:** https://northafricanorigins.com
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -10,9 +10,11 @@ in the same commit. A rule nobody enforces is worse than no rule.
 
 ## What this site is trying to be
 
-A bright, flat, poster-like site about one Amazigh family's deep ancestry, built for
-readers who are curious but not academic — teenagers and young adults first, specialists
-second. The evidence is scholarly. The presentation is not.
+A bright, flat, poster-like site about how migrations shaped North Africa's population,
+told from the published genetics, with one Amazigh family's deep ancestry as a worked
+example on its own page ("One family", `lineage.html`). It is built for readers who are
+curious but not academic — teenagers and young adults first, specialists second. The
+evidence is scholarly. The presentation is not.
 
 The previous system failed on this point in a specific, diagnosable way: one hue
 (warm brown) across every surface, a reading serif at every size, and a uniform grid
@@ -82,8 +84,9 @@ Four hues with genuine separation, so series are distinguished by hue, not by li
 ```
 
 Series colour is stable across the whole site: **the father's line is always sea, the
-mother's line is always yaz.** A reader who learns that on the homepage should not have
-to relearn it on any other page.
+mother's line is always yaz.** A reader who learns that on one page should not have
+to relearn it on another. Migration arrows are yaz as well: solid for ancestry arriving,
+dashed for ancestry leaving.
 
 **Colour is never the only cue.** Every series also carries a non-colour identifier — a
 dash pattern, a distinct marker shape, or a text label placed directly on the mark.

--- a/changelog/unreleased/feat-homepage-north-africa-story.md
+++ b/changelog/unreleased/feat-homepage-north-africa-story.md
@@ -1,0 +1,7 @@
+### Changed
+- The homepage now leads with how migrations shaped North Africa's population. It opens with a schematic of which ancestries arrived and which left, followed by a dated timeline running from roots more than 20,000 years deep to the Middle Ages. Each step links to its paper's summary and keeps the published range. The known gaps (the Roman to Byzantine centuries, ancient DNA from the Arab conquest, ancient Egypt) are named, not filled (#91)
+- The family case moved to its own tab, "One family" (`lineage.html`, same address), which now opens with the two lines' key figures. The nav, footer, Start here and the glossary all point to it (#91)
+- The footer, `DESIGN.md`, `CLAUDE.md` and the research scout's prompt now describe the region-wide scope (#91)
+
+### Fixed
+- The homepage said 11 papers and Start here said twelve; both now say thirteen, and the research scout keeps them in step with the research page (#91)

--- a/contact.html
+++ b/contact.html
@@ -58,7 +58,7 @@
       "name": "Contact | North African Origins",
       "url": "https://northafricanorigins.com/contact.html",
       "inLanguage": "en",
-      "dateModified": "2026-09-07"
+      "dateModified": "2026-09-10"
     }
     </script>
 </head>
@@ -83,7 +83,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="index.html">Home</a></li>
-                <li><a class="nav__link" href="lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="lineage.html">One family</a></li>
                 <li><a class="nav__link" href="genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="culture.html">Culture</a></li>
                 <li><a class="nav__link" href="research.html">Research</a></li>
@@ -208,7 +208,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated">Last updated: 10 September 2026</p>
             </div>
         </section>
 
@@ -222,7 +222,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="lineage.html">The two lines</a></li>
+                        <li><a href="lineage.html">One family</a></li>
                         <li><a href="genetics.html">DNA and haplogroups</a></li>
                         <li><a href="research.html">Papers and sources</a></li>
                         <li><a href="limitations.html">What this cannot show</a></li>
@@ -244,7 +244,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/culture.html
+++ b/culture.html
@@ -58,7 +58,7 @@
       "name": "Culture and language | Tachelhit and the Souss",
       "url": "https://northafricanorigins.com/culture.html",
       "inLanguage": "en",
-      "dateModified": "2026-09-07"
+      "dateModified": "2026-09-10"
     }
     </script>
 </head>
@@ -83,7 +83,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="index.html">Home</a></li>
-                <li><a class="nav__link" href="lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="lineage.html">One family</a></li>
                 <li><a class="nav__link" href="genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="culture.html" aria-current="page">Culture</a></li>
                 <li><a class="nav__link" href="research.html">Research</a></li>
@@ -256,7 +256,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated">Last updated: 10 September 2026</p>
             </div>
         </section>
 
@@ -270,7 +270,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="lineage.html">The two lines</a></li>
+                        <li><a href="lineage.html">One family</a></li>
                         <li><a href="genetics.html">DNA and haplogroups</a></li>
                         <li><a href="research.html">Papers and sources</a></li>
                         <li><a href="limitations.html">What this cannot show</a></li>
@@ -292,7 +292,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/genetics.html
+++ b/genetics.html
@@ -58,7 +58,7 @@
       "name": "What DNA can actually tell you | Haplogroups explained",
       "url": "https://northafricanorigins.com/genetics.html",
       "inLanguage": "en",
-      "dateModified": "2026-09-07"
+      "dateModified": "2026-09-10"
     }
     </script>
 </head>
@@ -83,7 +83,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="index.html">Home</a></li>
-                <li><a class="nav__link" href="lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="lineage.html">One family</a></li>
                 <li><a class="nav__link" href="genetics.html" aria-current="page">DNA</a></li>
                 <li><a class="nav__link" href="culture.html">Culture</a></li>
                 <li><a class="nav__link" href="research.html">Research</a></li>
@@ -251,7 +251,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated">Last updated: 10 September 2026</p>
             </div>
         </section>
 
@@ -265,7 +265,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="lineage.html">The two lines</a></li>
+                        <li><a href="lineage.html">One family</a></li>
                         <li><a href="genetics.html">DNA and haplogroups</a></li>
                         <li><a href="research.html">Papers and sources</a></li>
                         <li><a href="limitations.html">What this cannot show</a></li>
@@ -287,7 +287,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/glossary.html
+++ b/glossary.html
@@ -58,7 +58,7 @@
       "name": "Glossary | Haplogroups, TMRCA, admixture",
       "url": "https://northafricanorigins.com/glossary.html",
       "inLanguage": "en",
-      "dateModified": "2026-09-07"
+      "dateModified": "2026-09-10"
     }
     </script>
 </head>
@@ -83,7 +83,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="index.html" aria-current="page">Home</a></li>
-                <li><a class="nav__link" href="lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="lineage.html">One family</a></li>
                 <li><a class="nav__link" href="genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="culture.html">Culture</a></li>
                 <li><a class="nav__link" href="research.html">Research</a></li>
@@ -169,14 +169,14 @@
         <section class="band band--tight">
             <div class="container">
                 <div class="note">
-                    <p class="mb-0">These terms are used on <a href="lineage.html">the two lines</a>, <a href="genetics.html">DNA</a> and the <a href="research.html">research summaries</a>. If something on those pages is not defined here, that is a gap worth <a href="contact.html">telling me about</a>.</p>
+                    <p class="mb-0">These terms are used on <a href="index.html">the homepage</a>, <a href="lineage.html">One family</a>, <a href="genetics.html">DNA</a> and the <a href="research.html">research summaries</a>. If something on those pages is not defined here, that is a gap worth <a href="contact.html">telling me about</a>.</p>
                 </div>
             </div>
         </section>
 
         <section class="band band--tight">
             <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated">Last updated: 10 September 2026</p>
             </div>
         </section>
 
@@ -190,7 +190,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="lineage.html">The two lines</a></li>
+                        <li><a href="lineage.html">One family</a></li>
                         <li><a href="genetics.html">DNA and haplogroups</a></li>
                         <li><a href="research.html">Papers and sources</a></li>
                         <li><a href="limitations.html">What this cannot show</a></li>
@@ -212,7 +212,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/index.html
+++ b/index.html
@@ -5,22 +5,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <!-- SEO Meta Tags -->
-    <title>North African Origins | Amazigh DNA from Souss-Massa</title>
-    <meta name="description" content="Two DNA lines, one Amazigh family from Souss-Massa, Morocco. E-PF2546 rooted in Africa, H1-T16189C! arrived from Iberia. What the evidence actually shows.">
-    <meta name="keywords" content="Amazigh DNA, Berber genetics, Chtouka tribe, Souss-Massa heritage, E-PF2546, H1 haplogroup, Morocco genealogy, North African ancestry, Tachelhit culture">
+    <title>North African Origins | Ancient DNA and migrations</title>
+    <meta name="description" content="How 20,000 years of migrations shaped North Africa's population, told from peer-reviewed ancient-DNA and genome studies, with every published date range kept.">
+    <meta name="keywords" content="North African genetics, ancient DNA North Africa, Amazigh ancestry, Berber genetics, Maghreb migrations, Taforalt, Green Sahara, Neolithic Morocco, E-M81, North African origins">
     <meta name="author" content="North African Amazigh Heritage Project">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
     <meta name="language" content="English">
-    <meta name="geo.region" content="MA-09">
-    <meta name="geo.placename" content="Souss-Massa, Morocco">
-    <meta name="geo.position" content="30.3333;-9.2333">
-    <meta name="ICBM" content="30.3333, -9.2333">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="North African Origins">
-    <meta property="og:title" content="North African Origins | Amazigh DNA from Souss-Massa">
-    <meta property="og:description" content="Two DNA lines, one Amazigh family from Souss-Massa, Morocco. E-PF2546 rooted in Africa, H1-T16189C! arrived from Iberia. What the evidence actually shows.">
+    <meta property="og:title" content="North African Origins | Ancient DNA and migrations">
+    <meta property="og:description" content="How 20,000 years of migrations shaped North Africa's population, told from peer-reviewed ancient-DNA and genome studies, with every published date range kept.">
     <meta property="og:url" content="https://northafricanorigins.com/">
     <meta property="og:image" content="https://northafricanorigins.com/img/og-card.jpg">
     <meta property="og:image:width" content="1200">
@@ -29,14 +25,12 @@
     <meta property="og:image:alt" content="E-M81 Berber marker distribution across North Africa">
     <meta property="og:locale" content="en_US">
     <meta property="og:locale:alternate" content="fr_FR">
-    <meta property="og:locale:alternate" content="fr_FR">
-    <meta property="og:locale:alternate" content="fr_FR">
     <meta property="og:locale:alternate" content="ar_MA">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="North African Origins | Amazigh DNA from Souss-Massa">
-    <meta name="twitter:description" content="Two DNA lines, one Amazigh family from Souss-Massa. One African and unbroken, one that crossed from Iberia before farming reached Morocco.">
+    <meta name="twitter:title" content="North African Origins | Ancient DNA and migrations">
+    <meta name="twitter:description" content="Deep local roots, farmers from Iberia and the Levant, a green Sahara, Arab and sub-Saharan ancestry: how North Africa's population was made, layer by layer.">
     <meta name="twitter:image" content="https://northafricanorigins.com/img/og-card.jpg">
     <meta name="twitter:image:alt" content="Amazigh genetic heritage — E-M81 distribution map">
     <meta name="twitter:creator" content="@AmazighHeritage">
@@ -76,9 +70,9 @@
       "name": "North African Origins",
       "alternateName": "North African Amazigh Heritage",
       "url": "https://northafricanorigins.com/",
-      "description": "Two DNA lines, one Amazigh family from Souss-Massa, Morocco. E-PF2546 rooted in Africa, H1-T16189C! arrived from Iberia.",
+      "description": "How migrations shaped North Africa's population over 20,000 years, told from peer-reviewed ancient-DNA and genome studies.",
       "inLanguage": "en",
-      "dateModified": "2026-09-07"
+      "dateModified": "2026-09-10"
     }
     </script>
 </head>
@@ -103,7 +97,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="index.html" aria-current="page">Home</a></li>
-                <li><a class="nav__link" href="lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="lineage.html">One family</a></li>
                 <li><a class="nav__link" href="genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="culture.html">Culture</a></li>
                 <li><a class="nav__link" href="research.html">Research</a></li>
@@ -119,71 +113,97 @@
             <div class="container">
                 <div class="hero__grid">
                     <div>
-                        <span class="kicker">Souss-Massa, Morocco</span>
+                        <span class="kicker">North Africa &middot; 20,000 years</span>
                         <h1 class="hero__title">Who were we, <em>really</em>?</h1>
                         <div class="hero__actions">
-                            <a class="btn" href="lineage.html">Trace the two lines</a>
+                            <a class="btn" href="#made">See how it happened</a>
                             <a class="btn btn--ghost" href="start-here.html">New here? Start here</a>
                         </div>
                     </div>
-                    <p class="lead">One Amazigh (Berber) family from the Souss valley carries two ancestries that could hardly be more different. One never left Africa. The other crossed the sea from Iberia before farming reached Morocco.</p>
+                    <p class="lead">North Africans are not one people who arrived once. They are layers: deep local roots, joined again and again by farmers, traders and travellers, and sending people out across the sea in turn.</p>
                 </div>
             </div>
         </section>
 
         <hr class="stripe stripe--tall">
 
-        <!-- The two lines -->
-        <section class="band band--sunk" aria-labelledby="two-lines">
+        <!-- Who came, who left -->
+        <section class="band band--sunk" aria-labelledby="made">
             <div class="container">
                 <span class="kicker">The short version</span>
-                <h2 id="two-lines">Two lines that met in one valley</h2>
+                <h2 id="made">How North Africa was made</h2>
 
                 <figure class="figure">
                     <ul class="legend">
-                        <li><span class="legend__dot" style="background: var(--sea)"></span> Father's line — solid</li>
-                        <li><span class="legend__dot" style="background: var(--yaz)"></span> Mother's line — dashed</li>
+                        <li><span class="legend__dot" style="background: var(--yaz)"></span> Arriving — solid arrow</li>
+                        <li><span class="legend__dot" style="background: var(--yaz)"></span> Leaving — dashed arrow</li>
+                        <li><span class="legend__dot" style="background: var(--sea)"></span> Green Sahara — isolated, no arrow</li>
                     </ul>
                     <div class="figure__frame">
-                        <svg viewBox="0 0 900 400" role="img" aria-labelledby="dg1-title dg1-desc" class="dg">
-                            <title id="dg1-title">Two ancestral lines converging on Souss-Massa</title>
-                            <desc id="dg1-desc">The paternal line E-PF2546 descends within Africa for more than 65,000 years. The maternal line H1-T16189C! crosses from Iberia into North Africa between 8,000 and 11,000 years ago. Both meet in present-day Souss-Massa, Morocco.</desc>
+                        <svg viewBox="0 0 900 540" role="img" aria-labelledby="dgm-title dgm-desc" class="dg">
+                            <title id="dgm-title">How migrations shaped North Africa's population</title>
+                            <desc id="dgm-desc">A schematic, not a map. North Africa sits in the centre, with local roots going back more than 20,000 years. Solid arrows show ancestry arriving: farmers from Iberia between 7,500 and 5,000 years ago; farmers from the Levant in the same period, and Arab ancestry within the last 1,400 years; sub-Saharan African ancestry in two waves, around the 12th and 19th centuries CE. Dashed arrows show ancestry leaving: to the Canary Islands in the 1st millennium BCE, and to Sicily and Ibiza in the Middle Ages. The Green Sahara population of about 7,000 years ago stands on its own, with no arrow, because it was largely isolated.</desc>
 
-                            <!-- Origin blocks -->
-                            <rect x="20" y="20" width="330" height="56" fill="var(--sea)"></rect>
-                            <text class="dg-label" x="40" y="57" fill="var(--on-colour)" font-size="27">AFRICA</text>
+                            <!-- Neighbours to the north and east -->
+                            <rect x="40" y="24" width="240" height="56" fill="var(--sand)"></rect>
+                            <text class="dg-label" x="160" y="60" fill="var(--ink)" font-size="22" text-anchor="middle">IBERIA</text>
+                            <rect x="330" y="24" width="240" height="56" fill="var(--sand)"></rect>
+                            <text class="dg-label" x="450" y="60" fill="var(--ink)" font-size="22" text-anchor="middle">SICILY · IBIZA</text>
+                            <rect x="620" y="24" width="240" height="56" fill="var(--sand)"></rect>
+                            <text class="dg-label" x="740" y="60" fill="var(--ink)" font-size="22" text-anchor="middle">LEVANT · ARABIA</text>
 
-                            <rect x="550" y="20" width="330" height="56" fill="var(--yaz)"></rect>
-                            <text class="dg-label" x="570" y="57" fill="var(--on-colour)" font-size="27">EUROPE — IBERIA</text>
+                            <!-- North Africa -->
+                            <rect x="190" y="210" width="520" height="108" fill="var(--mountain)"></rect>
+                            <text class="dg-label" x="450" y="254" fill="var(--on-colour)" font-size="28" text-anchor="middle">NORTH AFRICA</text>
+                            <text class="dg-body" x="450" y="290" fill="var(--on-colour)" font-size="19" text-anchor="middle">Local roots, more than 20,000 years deep</text>
 
-                            <!-- Descent lines: solid vs dashed, so colour is not the only cue -->
-                            <path d="M110 76 V262" stroke="var(--sea)" stroke-width="11" fill="none"></path>
-                            <path d="M790 76 V262" stroke="var(--yaz)" stroke-width="11" fill="none" stroke-dasharray="20 14"></path>
+                            <!-- Canary Islands -->
+                            <text class="dg-label" x="75" y="224" fill="var(--ink)" font-size="17" text-anchor="middle">Settlers</text>
+                            <rect x="16" y="236" width="118" height="56" fill="var(--sand)"></rect>
+                            <text class="dg-label" x="75" y="270" fill="var(--ink)" font-size="17" text-anchor="middle">CANARIES</text>
+                            <text class="dg-meta" x="75" y="314" fill="var(--yaz)" font-size="13" text-anchor="middle">1st mill. BCE</text>
 
-                            <!-- Father's line labels -->
-                            <text class="dg-label" x="140" y="130" fill="var(--ink)" font-size="25">Father to son,</text>
-                            <text class="dg-label" x="140" y="160" fill="var(--ink)" font-size="25">never leaving Africa</text>
-                            <text class="dg-meta" x="140" y="200" fill="var(--sea)" font-size="20">E-PF2546</text>
-                            <text class="dg-body" x="140" y="234" fill="var(--ink-quiet)" font-size="19">65,000+ years of African descent</text>
+                            <!-- A: Iberia into North Africa (arriving, solid) -->
+                            <path d="M230 80 V190" stroke="var(--yaz)" stroke-width="6" fill="none"></path>
+                            <polygon points="221,190 239,190 230,206" fill="var(--yaz)"></polygon>
+                            <text class="dg-label" x="216" y="126" fill="var(--ink)" font-size="20" text-anchor="end">Farmers</text>
+                            <text class="dg-meta" x="216" y="150" fill="var(--yaz)" font-size="14" text-anchor="end">7,500–5,000 yrs ago</text>
 
-                            <!-- Mother's line labels -->
-                            <text class="dg-label" x="760" y="130" fill="var(--ink)" font-size="25" text-anchor="end">Mother to daughter,</text>
-                            <text class="dg-label" x="760" y="160" fill="var(--ink)" font-size="25" text-anchor="end">across the Strait</text>
-                            <text class="dg-meta" x="760" y="200" fill="var(--yaz)" font-size="20" text-anchor="end">H1-T16189C!</text>
-                            <text class="dg-body" x="760" y="234" fill="var(--ink-quiet)" font-size="19" text-anchor="end">arrived 8,000–11,000 years ago</text>
+                            <!-- B: North Africa to Sicily and Ibiza (leaving, dashed) -->
+                            <path d="M450 208 V98" stroke="var(--yaz)" stroke-width="6" fill="none" stroke-dasharray="14 10"></path>
+                            <polygon points="441,98 459,98 450,82" fill="var(--yaz)"></polygon>
+                            <text class="dg-label" x="464" y="126" fill="var(--ink)" font-size="20">Moves north</text>
+                            <text class="dg-meta" x="464" y="150" fill="var(--yaz)" font-size="14">Middle Ages</text>
 
-                            <!-- Convergence -->
-                            <path d="M110 262 V300 H450" stroke="var(--sea)" stroke-width="11" fill="none"></path>
-                            <path d="M790 262 V300 H450" stroke="var(--yaz)" stroke-width="11" fill="none" stroke-dasharray="20 14"></path>
-                            <path d="M450 300 V326" stroke="var(--ink)" stroke-width="11" fill="none"></path>
+                            <!-- C: Levant and Arabia into North Africa (arriving, solid) -->
+                            <path d="M680 80 V190" stroke="var(--yaz)" stroke-width="6" fill="none"></path>
+                            <polygon points="671,190 689,190 680,206" fill="var(--yaz)"></polygon>
+                            <text class="dg-label" x="694" y="116" fill="var(--ink)" font-size="20">Farmers, then</text>
+                            <text class="dg-label" x="694" y="140" fill="var(--ink)" font-size="20">Arab ancestry</text>
+                            <text class="dg-meta" x="694" y="164" fill="var(--yaz)" font-size="14">7,500–5,000 yrs ago</text>
+                            <text class="dg-meta" x="694" y="186" fill="var(--yaz)" font-size="14">last 1,400 yrs</text>
 
-                            <!-- Meeting point -->
-                            <rect x="235" y="326" width="430" height="62" fill="var(--mountain)"></rect>
-                            <text class="dg-label" x="450" y="353" fill="var(--on-colour)" font-size="24" text-anchor="middle">SOUSS-MASSA, MOROCCO</text>
-                            <text class="dg-body" x="450" y="376" fill="var(--on-colour)" font-size="18" text-anchor="middle">Aït Moussa, of the Chtouka confederation</text>
+                            <!-- D: North Africa to the Canaries (leaving, dashed) -->
+                            <path d="M188 264 H152" stroke="var(--yaz)" stroke-width="6" fill="none" stroke-dasharray="12 8"></path>
+                            <polygon points="152,255 152,273 136,264" fill="var(--yaz)"></polygon>
+
+                            <!-- Green Sahara: isolated, so no arrow -->
+                            <rect x="190" y="350" width="400" height="60" fill="var(--sea)"></rect>
+                            <text class="dg-label" x="390" y="377" fill="var(--on-colour)" font-size="21" text-anchor="middle">GREEN SAHARA</text>
+                            <text class="dg-body" x="390" y="399" fill="var(--on-colour)" font-size="15" text-anchor="middle">About 7,000 years ago: an isolated lineage</text>
+
+                            <!-- Sub-Saharan Africa -->
+                            <rect x="190" y="462" width="520" height="56" fill="var(--sand)"></rect>
+                            <text class="dg-label" x="450" y="497" fill="var(--ink)" font-size="21" text-anchor="middle">SUB-SAHARAN AFRICA</text>
+
+                            <!-- E: sub-Saharan Africa into North Africa (arriving, solid) -->
+                            <path d="M650 462 V338" stroke="var(--yaz)" stroke-width="6" fill="none"></path>
+                            <polygon points="641,338 659,338 650,322" fill="var(--yaz)"></polygon>
+                            <text class="dg-label" x="664" y="392" fill="var(--ink)" font-size="20">Two waves</text>
+                            <text class="dg-meta" x="664" y="416" fill="var(--yaz)" font-size="14">12th and 19th c. CE</text>
                         </svg>
                     </div>
-                    <figcaption class="figure__caption"><b>Two lines, two completely different pasts.</b> The paternal line is autochthonous to North Africa. The maternal line is a European lineage that became North African thousands of years before anything was written down. Both are equally ancestral.</figcaption>
+                    <figcaption class="figure__caption"><b>Layers, not replacements.</b> The studies summarised here describe newcomers mixing with people already in North Africa rather than replacing them, and movement running outward too. A schematic, not a map: positions are approximate, and the dates are the published ranges.</figcaption>
                 </figure>
             </div>
         </section>
@@ -194,75 +214,154 @@
                 <h2 id="numbers" class="mt-0">The numbers that matter</h2>
                 <div class="stat-row">
                     <div class="stat stat--sea">
-                        <span class="stat__num">65,000+</span>
-                        <span class="stat__label">Years African, father to son</span>
-                    </div>
-                    <div class="stat stat--sea">
-                        <span class="stat__num">~400 BCE</span>
-                        <span class="stat__label">Origin of branch <span class="hg">E-PF2546</span></span>
+                        <span class="stat__num">20,000+</span>
+                        <span class="stat__label">Years of roots in North Africa</span>
                     </div>
                     <div class="stat stat--yaz">
-                        <span class="stat__num">8–11k</span>
-                        <span class="stat__label">Years since <span class="hg">H1</span> crossed from Iberia</span>
+                        <span class="stat__num">7.5–5k</span>
+                        <span class="stat__label">Years ago, farmers crossed from Iberia and the Levant</span>
+                    </div>
+                    <div class="stat">
+                        <span class="stat__num">2</span>
+                        <span class="stat__label">Waves of sub-Saharan ancestry, 12th and 19th c. CE</span>
                     </div>
                     <div class="stat stat--mountain">
-                        <span class="stat__num">11</span>
-                        <span class="stat__label">Peer-reviewed papers summarised</span>
+                        <span class="stat__num">13</span>
+                        <span class="stat__label">Peer-reviewed papers behind this page</span>
                     </div>
                 </div>
-                <p class="figure__caption">Every figure here is an estimate with a published range, not a fixed date. The ranges are given in full on <a href="lineage.html">the two lines</a>.</p>
+                <p class="figure__caption">Every figure is an estimate with a published range. The ranges are in the timeline below, each linked to its paper.</p>
+            </div>
+        </section>
+
+        <!-- The layers -->
+        <section class="band band--sunk" aria-labelledby="layers">
+            <div class="container">
+                <span class="kicker">Oldest first</span>
+                <h2 id="layers">The layers, in order</h2>
+                <p class="prose">Each step comes from a peer-reviewed study summarised on this site, with its published date range. The link takes you to the summary and, from there, to the paper.</p>
+
+                <ul class="eras">
+                    <li class="era">
+                        <span class="era__when">More than 20,000 years ago</span>
+                        <div>
+                            <h3 class="era__what">Roots that go deep</h3>
+                            <p class="era__note">The ancestry of today's Amazigh (Berber) people goes back more than 20,000 years in North Africa, to a movement back into Africa from Eurasia. Genome modelling puts the first separation between the region's Amazigh and Arab populations that far back: a slow drift apart, not a clean break (<a href="research/north-africa-demographic-history-2024.html">Serradell et al. 2024</a>).</p>
+                        </div>
+                    </li>
+                    <li class="era">
+                        <span class="era__when">15,100–13,900 years ago</span>
+                        <div>
+                            <h3 class="era__what">The Taforalt foragers</h3>
+                            <p class="era__note">The deepest layer that can be measured in Amazigh genomes today links to the Iberomaurusian foragers of Taforalt, in Morocco (<a href="research/amazigh-genomic-heterogeneity-2024.html">Vilà-Valls et al. 2024</a>).</p>
+                        </div>
+                    </li>
+                    <li class="era">
+                        <span class="era__when">About 15,000–7,600 years ago</span>
+                        <div>
+                            <h3 class="era__what">One local ancestry, west to east</h3>
+                            <p class="era__note">The same Maghrebi forager profile ran from Morocco to Algeria and Tunisia for thousands of years. Around 8,000 years ago, one person in Tunisia already carried ancestry related to European hunter-gatherers (<a href="research/eastern-maghreb-neolithic-continuity-2025.html">Lipson et al. 2025</a>).</p>
+                        </div>
+                    </li>
+                    <li class="era">
+                        <span class="era__when">About 7,500–5,000 years ago</span>
+                        <div>
+                            <h3 class="era__what">Farming arrives with people</h3>
+                            <p class="era__note">Early farmers in Morocco carried two incoming ancestries, from Iberian farmers who crossed the Strait of Gibraltar and from Levantine farmers, mixed with local foragers rather than replacing them (<a href="research/neolithic-iberia-morocco-2023.html">Villalba-Mouco et al. 2023</a>). Further east, local ancestry held on, with smaller farmer contributions by about 7,000–6,800 years ago (<a href="research/eastern-maghreb-neolithic-continuity-2025.html">Lipson et al. 2025</a>).</p>
+                        </div>
+                    </li>
+                    <li class="era">
+                        <span class="era__when">About 7,000 years ago</span>
+                        <div>
+                            <h3 class="era__what">A green Sahara</h3>
+                            <p class="era__note">Genomes from Takarkori, in Libya, date to a time when the Sahara was grassland. They carry a previously unknown, deeply divergent lineage from a population that was largely isolated from its neighbours (<a href="research/green-sahara-ancient-dna-2025.html">Salem et al. 2025</a>).</p>
+                        </div>
+                    </li>
+                    <li class="era">
+                        <span class="era__when">Late Pleistocene to recent times</span>
+                        <div>
+                            <h3 class="era__what">Women's lines, in waves</h3>
+                            <p class="era__note">Complete mitochondrial genomes show several waves of female-mediated movement shaping the region (<a href="research/north-african-mitogenomes-2025.html">Colombo et al. 2025</a>), on top of a maternal core so shared that populations across the Maghreb differ only slightly from one another (<a href="research/north-africa-maternal-diversity-2026.html">Boumajdi et al. 2026</a>).</p>
+                        </div>
+                    </li>
+                    <li class="era">
+                        <span class="era__when">About 2,000–3,000 years ago</span>
+                        <div>
+                            <h3 class="era__what">One father's line spreads fast</h3>
+                            <p class="era__note"><span class="hg">E-M81</span>, the most common Y-chromosome among Amazigh men, traces back to a small founding group that expanded quickly (<a href="research/e-m183-recent-origin-2018.html">Solé-Morata et al. 2017</a>).</p>
+                        </div>
+                    </li>
+                    <li class="era">
+                        <span class="era__when">1st millennium BCE</span>
+                        <div>
+                            <h3 class="era__what">Out into the Atlantic</h3>
+                            <p class="era__note">Amazigh settlers reached the Canary Islands. Their descendants stayed genetically close to mainland North Africans until the European conquest of the 15th century (<a href="research/canary-islands-amazigh-history-2025.html">Santana et al. 2025</a>).</p>
+                        </div>
+                    </li>
+                    <li class="era">
+                        <span class="era__when">The Punic period</span>
+                        <div>
+                            <h3 class="era__what">Culture travels further than people</h3>
+                            <p class="era__note">Punic settlements across the Mediterranean carried little Levantine ancestry, despite their Phoenician culture. Most was related to groups from Sicily and the Aegean, with a recurring North African share linked to Carthage (<a href="research/punic-genetic-diversity-2025.html">Reich et al. 2025</a>).</p>
+                        </div>
+                    </li>
+                    <li class="era">
+                        <span class="era__when">The Middle Ages</span>
+                        <div>
+                            <h3 class="era__what">North Africa moves north</h3>
+                            <p class="era__note">North African ancestry reached Sicily before the Islamic conquest (<a href="research/medieval-sicily-north-african-ancestry-2026.html">Monnereau et al. 2026</a>), and Ibiza in two pulses, in the 10th and 12th centuries CE (<a href="research/mediterranean-islamic-dna-ibiza-2026.html">Rodríguez-Varela et al. 2026</a>).</p>
+                        </div>
+                    </li>
+                    <li class="era">
+                        <span class="era__when">The last 1,400 years</span>
+                        <div>
+                            <h3 class="era__what">Arabization, and two Saharan waves</h3>
+                            <p class="era__note">Arab genetic input into North Africa is recent, mostly within the last 1,400 years (<a href="research/north-africa-demographic-history-2024.html">Serradell et al. 2024</a>). Sub-Saharan ancestry reached Amazigh groups in at least two waves, around the 12th and 19th centuries CE, strongest near the caravan routes (<a href="research/amazigh-genomic-heterogeneity-2024.html">Vilà-Valls et al. 2024</a>).</p>
+                        </div>
+                    </li>
+                </ul>
+            </div>
+        </section>
+
+        <!-- Gaps -->
+        <section class="band band--sand band--tight" aria-labelledby="gaps">
+            <div class="container">
+                <div class="note" style="background: transparent; border-left-color: var(--ink)">
+                    <h2 id="gaps" class="mt-0">What these papers do not cover yet</h2>
+                    <p>The studies summarised here say little about North Africa in the Roman, Vandal and Byzantine centuries. None has ancient DNA from the 7th-century Arab conquest itself: the dating of Arab ancestry above comes from the genomes of people alive today. And none covers ancient Egypt or the Nile valley.</p>
+                    <p class="mb-0">Until a study does, this page says nothing about them. <a href="limitations.html">What this evidence cannot show</a> sets out the other limits.</p>
+                </div>
             </div>
         </section>
 
         <!-- Doors -->
-        <section class="band band--sunk band--tight" aria-labelledby="doors">
+        <section class="band" aria-labelledby="doors">
             <div class="container">
-                <h2 id="doors" class="mt-0">Three ways in</h2>
+                <h2 id="doors" class="mt-0">Where to go next</h2>
                 <div class="doors">
-                    <a class="door door--sea" href="genetics.html">
+                    <a class="door door--mountain" href="lineage.html">
                         <span class="door__go">01</span>
                         <span>
-                            <span class="door__title">DNA</span>
-                            <span class="door__text">What a haplogroup actually is, how the dates are calculated, and why a Y-chromosome and a mitochondrion tell you different halves of a story.</span>
+                            <span class="door__title">One family</span>
+                            <span class="door__text">One Amazigh family from the Souss valley, traced through two DNA lines: a worked example of everything above.</span>
                         </span>
                     </a>
-                    <a class="door door--sand" href="maps-sites.html">
+                    <a class="door door--sea" href="genetics.html">
                         <span class="door__go">02</span>
                         <span>
-                            <span class="door__title">Land</span>
-                            <span class="door__text">The Souss plain, the Anti-Atlas, and the valley of Aït Moussa — the ground this family has farmed and herded for centuries.</span>
+                            <span class="door__title">DNA</span>
+                            <span class="door__text">What a haplogroup is, how the dates are calculated, and what ancient DNA changed.</span>
                         </span>
                     </a>
-                    <a class="door door--mountain" href="culture.html">
+                    <a class="door door--sand" href="research.html">
                         <span class="door__go">03</span>
                         <span>
-                            <span class="door__title">Language</span>
-                            <span class="door__text">Tachelhit, still the most spoken Amazigh language in Morocco, with a written literature going back to the 16th century.</span>
+                            <span class="door__title">Research</span>
+                            <span class="door__text">Every paper behind this page, each with a plain-language summary and its DOI.</span>
                         </span>
                     </a>
                 </div>
-            </div>
-        </section>
-
-        <!-- Honesty note -->
-        <section class="band band--ink band--tight" aria-labelledby="honest">
-            <div class="container">
-                <div class="hero__grid">
-                    <div>
-                        <span class="kicker">Read this before you believe any of it</span>
-                        <h2 id="honest" class="mt-0">Two lines out of a thousand</h2>
-                    </div>
-                    <div class="prose">
-                        <p>A Y-chromosome and a mitochondrion are two threads out of the many thousands that make up an ancestry. They are not an ethnicity, they are not a nationality, and they cannot tell you what anyone looked like or believed.</p>
-                        <p><a href="limitations.html">What this evidence cannot show</a></p>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <section class="band band--tight">
-            <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated" style="margin-top: var(--gap)">Last updated: 10 September 2026</p>
             </div>
         </section>
 
@@ -276,7 +375,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="lineage.html">The two lines</a></li>
+                        <li><a href="lineage.html">One family</a></li>
                         <li><a href="genetics.html">DNA and haplogroups</a></li>
                         <li><a href="research.html">Papers and sources</a></li>
                         <li><a href="limitations.html">What this cannot show</a></li>
@@ -298,7 +397,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/limitations.html
+++ b/limitations.html
@@ -64,7 +64,7 @@
       "name": "What this evidence cannot show | Limitations",
       "url": "https://northafricanorigins.com/limitations.html",
       "inLanguage": "en",
-      "dateModified": "2026-09-07"
+      "dateModified": "2026-09-10"
     }
     </script>
 </head>
@@ -89,7 +89,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="index.html" aria-current="page">Home</a></li>
-                <li><a class="nav__link" href="lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="lineage.html">One family</a></li>
                 <li><a class="nav__link" href="genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="culture.html">Culture</a></li>
                 <li><a class="nav__link" href="research.html">Research</a></li>
@@ -160,7 +160,7 @@
                 </div>
 
                 <div class="prose">
-                    <p class="mb-0">This site conflated those two H1 figures until September 2026. <a href="lineage.html">The two lines</a> now quotes the North African coalescence, because that is the one relevant to when this maternal line arrived in the Maghreb. Where a single figure appears anywhere on this site, it is a midpoint — and the range is what the evidence actually supports.</p>
+                    <p class="mb-0">This site conflated those two H1 figures until September 2026. <a href="lineage.html">One family</a> now quotes the North African coalescence, because that is the one relevant to when this maternal line arrived in the Maghreb. Where a single figure appears anywhere on this site, it is a midpoint — and the range is what the evidence actually supports.</p>
                 </div>
             </div>
         </section>
@@ -205,7 +205,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated">Last updated: 10 September 2026</p>
             </div>
         </section>
 
@@ -219,7 +219,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="lineage.html">The two lines</a></li>
+                        <li><a href="lineage.html">One family</a></li>
                         <li><a href="genetics.html">DNA and haplogroups</a></li>
                         <li><a href="research.html">Papers and sources</a></li>
                         <li><a href="limitations.html">What this cannot show</a></li>
@@ -241,7 +241,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/lineage.html
+++ b/lineage.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <title>The two lines | E-PF2546 and H1-T16189C!</title>
+    <title>One family, two lines | E-PF2546 and H1-T16189C!</title>
     <meta name="description" content="One Amazigh family, two ancestries: E-PF2546 rooted in Africa for 65,000 years, and H1-T16189C! which crossed from Iberia 8,000-11,000 years ago.">
     <meta name="keywords" content="E-PF2546, H1-T16189C!, E-M81, Amazigh lineage, Chtouka, Souss-Massa, asymmetrical admixture, Berber Y-DNA, North African mtDNA">
     <meta name="author" content="North African Amazigh Heritage Project">
@@ -14,7 +14,7 @@
 
     <meta property="og:type" content="article">
     <meta property="og:site_name" content="North African Origins">
-    <meta property="og:title" content="The two lines | E-PF2546 and H1-T16189C!">
+    <meta property="og:title" content="One family, two lines | E-PF2546 and H1-T16189C!">
     <meta property="og:description" content="One Amazigh family, two ancestries: E-PF2546 rooted in Africa for 65,000 years, and H1-T16189C! which crossed from Iberia 8,000-11,000 years ago.">
     <meta property="og:url" content="https://northafricanorigins.com/lineage.html">
     <meta property="og:image" content="https://northafricanorigins.com/img/og-card.jpg">
@@ -24,7 +24,7 @@
     <meta property="og:image:alt" content="E-M81 Berber marker distribution across North Africa">
 
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="The two lines | E-PF2546 and H1-T16189C!">
+    <meta name="twitter:title" content="One family, two lines | E-PF2546 and H1-T16189C!">
     <meta name="twitter:description" content="One African father-line, one European mother-line, and the prehistoric migration that explains how they met.">
     <meta name="twitter:image" content="https://northafricanorigins.com/img/og-card.jpg">
     <meta name="twitter:image:alt" content="Amazigh genetic heritage — E-M81 distribution map">
@@ -51,7 +51,7 @@
     {
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "The two lines: E-PF2546 and H1-T16189C!",
+      "headline": "One family, two lines: E-PF2546 and H1-T16189C!",
       "description": "One Amazigh family, two ancestries: E-PF2546 rooted in Africa, and H1-T16189C! which crossed from Iberia 8,000-11,000 years ago.",
       "url": "https://northafricanorigins.com/lineage.html",
       "inLanguage": "en",
@@ -84,7 +84,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="index.html">Home</a></li>
-                <li><a class="nav__link" href="lineage.html" aria-current="page">The two lines</a></li>
+                <li><a class="nav__link" href="lineage.html" aria-current="page">One family</a></li>
                 <li><a class="nav__link" href="genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="culture.html">Culture</a></li>
                 <li><a class="nav__link" href="research.html">Research</a></li>
@@ -95,7 +95,7 @@
 
     <div class="container">
         <nav class="breadcrumb" aria-label="Breadcrumb">
-            <a href="index.html">Home</a> &rsaquo; The two lines
+            <a href="index.html">Home</a> &rsaquo; One family
         </nav>
     </div>
 
@@ -104,8 +104,24 @@
         <section class="band band--tight">
             <div class="container">
                 <span class="kicker">Aït Moussa &middot; Chtouka confederation</span>
-                <h1 class="page-title">The two lines</h1>
-                <p class="lead">A Y-chromosome that has been in Africa for more than 65,000 years, and a mitochondrial line that crossed from Iberia before anyone in Morocco had planted a crop. Here is how they met.</p>
+                <h1 class="page-title">One family, two lines</h1>
+                <p class="lead">One Amazigh (Berber) family from the Souss valley, as a worked example of <a href="index.html">how North Africa was made</a>. Its Y-chromosome has been in Africa for more than 65,000 years; its mitochondrial line crossed from Iberia before anyone in Morocco had planted a crop. Here is how they met.</p>
+
+                <div class="stat-row" style="margin-top: var(--gap)">
+                    <div class="stat stat--sea">
+                        <span class="stat__num">65,000+</span>
+                        <span class="stat__label">Years African, father to son</span>
+                    </div>
+                    <div class="stat stat--sea">
+                        <span class="stat__num">~400 BCE</span>
+                        <span class="stat__label">Origin of branch <span class="hg">E-PF2546</span></span>
+                    </div>
+                    <div class="stat stat--yaz">
+                        <span class="stat__num">8–11k</span>
+                        <span class="stat__label">Years since <span class="hg">H1</span> crossed from Iberia</span>
+                    </div>
+                </div>
+                <p class="figure__caption">Each figure is an estimate with a published range, given in full below.</p>
 
                 <ul class="section-nav">
                     <li><a href="#deep-time">Deep time</a></li>
@@ -380,7 +396,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="lineage.html">The two lines</a></li>
+                        <li><a href="lineage.html">One family</a></li>
                         <li><a href="genetics.html">DNA and haplogroups</a></li>
                         <li><a href="research.html">Papers and sources</a></li>
                         <li><a href="limitations.html">What this cannot show</a></li>
@@ -402,7 +418,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/maps-sites.html
+++ b/maps-sites.html
@@ -58,7 +58,7 @@
       "name": "Maps and sites | Takarkori, Morocco, Souss-Massa",
       "url": "https://northafricanorigins.com/maps-sites.html",
       "inLanguage": "en",
-      "dateModified": "2026-09-07"
+      "dateModified": "2026-09-10"
     }
     </script>
 </head>
@@ -83,7 +83,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="index.html" aria-current="page">Home</a></li>
-                <li><a class="nav__link" href="lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="lineage.html">One family</a></li>
                 <li><a class="nav__link" href="genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="culture.html">Culture</a></li>
                 <li><a class="nav__link" href="research.html">Research</a></li>
@@ -182,7 +182,7 @@
 
         <section class="band band--tight">
             <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated">Last updated: 10 September 2026</p>
             </div>
         </section>
 
@@ -196,7 +196,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="lineage.html">The two lines</a></li>
+                        <li><a href="lineage.html">One family</a></li>
                         <li><a href="genetics.html">DNA and haplogroups</a></li>
                         <li><a href="research.html">Papers and sources</a></li>
                         <li><a href="limitations.html">What this cannot show</a></li>
@@ -218,7 +218,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/research.html
+++ b/research.html
@@ -83,7 +83,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="index.html">Home</a></li>
-                <li><a class="nav__link" href="lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="lineage.html">One family</a></li>
                 <li><a class="nav__link" href="genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="culture.html">Culture</a></li>
                 <li><a class="nav__link" href="research.html" aria-current="page">Research</a></li>
@@ -165,7 +165,7 @@
                         </div>
                         <div>
                             <h3 class="paper__title"><a href="research/north-african-mitogenomes-2025.html">733 modern and 43 ancient mitogenomes</a></h3>
-                            <p class="paper__finding">A large survey of North African maternal lineages, including the H1 subclade patterns that underlie the maternal half of this lineage.</p>
+                            <p class="paper__finding">A large survey of North African maternal lineages, including the H1 subclade patterns that underlie the maternal half of the family case on this site.</p>
                             <p class="paper__meta">Colombo et al. &middot; <cite class="paper__journal">Scientific Reports</cite> &middot; <a href="https://doi.org/10.1038/s41598-025-12209-x">doi:10.1038/s41598-025-12209-x</a></p>
                         </div>
                     </li>
@@ -176,7 +176,7 @@
                         </div>
                         <div>
                             <h3 class="paper__title"><a href="research/canary-islands-amazigh-history-2025.html">The Guanches before European contact</a></h3>
-                            <p class="paper__finding">Demographic history of the indigenous Canarian Amazigh, whose ancestors sailed from North Africa. The same paternal branch as this lineage has been reported among them.</p>
+                            <p class="paper__finding">Demographic history of the indigenous Canarian Amazigh, whose ancestors sailed from North Africa. The same paternal branch as the family case on this site has been reported among them.</p>
                             <p class="paper__meta">Santana et al. &middot; <cite class="paper__journal">Scientific Reports</cite> &middot; <a href="https://doi.org/10.1038/s41598-025-04302-y">doi:10.1038/s41598-025-04302-y</a></p>
                         </div>
                     </li>
@@ -287,7 +287,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="lineage.html">The two lines</a></li>
+                        <li><a href="lineage.html">One family</a></li>
                         <li><a href="genetics.html">DNA and haplogroups</a></li>
                         <li><a href="research.html">Papers and sources</a></li>
                         <li><a href="limitations.html">What this cannot show</a></li>
@@ -309,7 +309,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/research/amazigh-genomic-heterogeneity-2024.html
+++ b/research/amazigh-genomic-heterogeneity-2024.html
@@ -84,7 +84,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="../index.html">Home</a></li>
-                <li><a class="nav__link" href="../lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="../lineage.html">One family</a></li>
                 <li><a class="nav__link" href="../genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="../culture.html">Culture</a></li>
                 <li><a class="nav__link" href="../research.html" aria-current="page">Research</a></li>
@@ -175,7 +175,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="../lineage.html">The two lines</a></li>
+                        <li><a href="../lineage.html">One family</a></li>
                         <li><a href="../genetics.html">DNA and haplogroups</a></li>
                         <li><a href="../research.html">Papers and sources</a></li>
                         <li><a href="../limitations.html">What this cannot show</a></li>
@@ -197,7 +197,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/research/canary-islanders-exome-ancestry-2026.html
+++ b/research/canary-islanders-exome-ancestry-2026.html
@@ -84,7 +84,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="../index.html">Home</a></li>
-                <li><a class="nav__link" href="../lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="../lineage.html">One family</a></li>
                 <li><a class="nav__link" href="../genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="../culture.html">Culture</a></li>
                 <li><a class="nav__link" href="../research.html" aria-current="page">Research</a></li>
@@ -171,7 +171,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="../lineage.html">The two lines</a></li>
+                        <li><a href="../lineage.html">One family</a></li>
                         <li><a href="../genetics.html">DNA and haplogroups</a></li>
                         <li><a href="../research.html">Papers and sources</a></li>
                         <li><a href="../limitations.html">What this cannot show</a></li>
@@ -193,7 +193,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/research/canary-islands-amazigh-history-2025.html
+++ b/research/canary-islands-amazigh-history-2025.html
@@ -84,7 +84,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="../index.html">Home</a></li>
-                <li><a class="nav__link" href="../lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="../lineage.html">One family</a></li>
                 <li><a class="nav__link" href="../genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="../culture.html">Culture</a></li>
                 <li><a class="nav__link" href="../research.html" aria-current="page">Research</a></li>
@@ -170,7 +170,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="../lineage.html">The two lines</a></li>
+                        <li><a href="../lineage.html">One family</a></li>
                         <li><a href="../genetics.html">DNA and haplogroups</a></li>
                         <li><a href="../research.html">Papers and sources</a></li>
                         <li><a href="../limitations.html">What this cannot show</a></li>
@@ -192,7 +192,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/research/e-m183-recent-origin-2018.html
+++ b/research/e-m183-recent-origin-2018.html
@@ -84,7 +84,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="../index.html">Home</a></li>
-                <li><a class="nav__link" href="../lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="../lineage.html">One family</a></li>
                 <li><a class="nav__link" href="../genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="../culture.html">Culture</a></li>
                 <li><a class="nav__link" href="../research.html" aria-current="page">Research</a></li>
@@ -174,7 +174,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="../lineage.html">The two lines</a></li>
+                        <li><a href="../lineage.html">One family</a></li>
                         <li><a href="../genetics.html">DNA and haplogroups</a></li>
                         <li><a href="../research.html">Papers and sources</a></li>
                         <li><a href="../limitations.html">What this cannot show</a></li>
@@ -196,7 +196,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/research/eastern-maghreb-neolithic-continuity-2025.html
+++ b/research/eastern-maghreb-neolithic-continuity-2025.html
@@ -84,7 +84,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="../index.html">Home</a></li>
-                <li><a class="nav__link" href="../lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="../lineage.html">One family</a></li>
                 <li><a class="nav__link" href="../genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="../culture.html">Culture</a></li>
                 <li><a class="nav__link" href="../research.html" aria-current="page">Research</a></li>
@@ -173,7 +173,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="../lineage.html">The two lines</a></li>
+                        <li><a href="../lineage.html">One family</a></li>
                         <li><a href="../genetics.html">DNA and haplogroups</a></li>
                         <li><a href="../research.html">Papers and sources</a></li>
                         <li><a href="../limitations.html">What this cannot show</a></li>
@@ -195,7 +195,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/research/green-sahara-ancient-dna-2025.html
+++ b/research/green-sahara-ancient-dna-2025.html
@@ -84,7 +84,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="../index.html">Home</a></li>
-                <li><a class="nav__link" href="../lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="../lineage.html">One family</a></li>
                 <li><a class="nav__link" href="../genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="../culture.html">Culture</a></li>
                 <li><a class="nav__link" href="../research.html" aria-current="page">Research</a></li>
@@ -174,7 +174,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="../lineage.html">The two lines</a></li>
+                        <li><a href="../lineage.html">One family</a></li>
                         <li><a href="../genetics.html">DNA and haplogroups</a></li>
                         <li><a href="../research.html">Papers and sources</a></li>
                         <li><a href="../limitations.html">What this cannot show</a></li>
@@ -196,7 +196,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/research/medieval-sicily-north-african-ancestry-2026.html
+++ b/research/medieval-sicily-north-african-ancestry-2026.html
@@ -84,7 +84,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="../index.html">Home</a></li>
-                <li><a class="nav__link" href="../lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="../lineage.html">One family</a></li>
                 <li><a class="nav__link" href="../genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="../culture.html">Culture</a></li>
                 <li><a class="nav__link" href="../research.html" aria-current="page">Research</a></li>
@@ -171,7 +171,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="../lineage.html">The two lines</a></li>
+                        <li><a href="../lineage.html">One family</a></li>
                         <li><a href="../genetics.html">DNA and haplogroups</a></li>
                         <li><a href="../research.html">Papers and sources</a></li>
                         <li><a href="../limitations.html">What this cannot show</a></li>
@@ -193,7 +193,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/research/mediterranean-islamic-dna-ibiza-2026.html
+++ b/research/mediterranean-islamic-dna-ibiza-2026.html
@@ -84,7 +84,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="../index.html">Home</a></li>
-                <li><a class="nav__link" href="../lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="../lineage.html">One family</a></li>
                 <li><a class="nav__link" href="../genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="../culture.html">Culture</a></li>
                 <li><a class="nav__link" href="../research.html" aria-current="page">Research</a></li>
@@ -172,7 +172,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="../lineage.html">The two lines</a></li>
+                        <li><a href="../lineage.html">One family</a></li>
                         <li><a href="../genetics.html">DNA and haplogroups</a></li>
                         <li><a href="../research.html">Papers and sources</a></li>
                         <li><a href="../limitations.html">What this cannot show</a></li>
@@ -194,7 +194,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/research/neolithic-iberia-morocco-2023.html
+++ b/research/neolithic-iberia-morocco-2023.html
@@ -84,7 +84,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="../index.html">Home</a></li>
-                <li><a class="nav__link" href="../lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="../lineage.html">One family</a></li>
                 <li><a class="nav__link" href="../genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="../culture.html">Culture</a></li>
                 <li><a class="nav__link" href="../research.html" aria-current="page">Research</a></li>
@@ -174,7 +174,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="../lineage.html">The two lines</a></li>
+                        <li><a href="../lineage.html">One family</a></li>
                         <li><a href="../genetics.html">DNA and haplogroups</a></li>
                         <li><a href="../research.html">Papers and sources</a></li>
                         <li><a href="../limitations.html">What this cannot show</a></li>
@@ -196,7 +196,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/research/north-africa-demographic-history-2024.html
+++ b/research/north-africa-demographic-history-2024.html
@@ -84,7 +84,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="../index.html">Home</a></li>
-                <li><a class="nav__link" href="../lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="../lineage.html">One family</a></li>
                 <li><a class="nav__link" href="../genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="../culture.html">Culture</a></li>
                 <li><a class="nav__link" href="../research.html" aria-current="page">Research</a></li>
@@ -175,7 +175,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="../lineage.html">The two lines</a></li>
+                        <li><a href="../lineage.html">One family</a></li>
                         <li><a href="../genetics.html">DNA and haplogroups</a></li>
                         <li><a href="../research.html">Papers and sources</a></li>
                         <li><a href="../limitations.html">What this cannot show</a></li>
@@ -197,7 +197,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/research/north-africa-maternal-diversity-2026.html
+++ b/research/north-africa-maternal-diversity-2026.html
@@ -84,7 +84,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="../index.html">Home</a></li>
-                <li><a class="nav__link" href="../lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="../lineage.html">One family</a></li>
                 <li><a class="nav__link" href="../genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="../culture.html">Culture</a></li>
                 <li><a class="nav__link" href="../research.html" aria-current="page">Research</a></li>
@@ -173,7 +173,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="../lineage.html">The two lines</a></li>
+                        <li><a href="../lineage.html">One family</a></li>
                         <li><a href="../genetics.html">DNA and haplogroups</a></li>
                         <li><a href="../research.html">Papers and sources</a></li>
                         <li><a href="../limitations.html">What this cannot show</a></li>
@@ -195,7 +195,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/research/north-african-mitogenomes-2025.html
+++ b/research/north-african-mitogenomes-2025.html
@@ -84,7 +84,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="../index.html">Home</a></li>
-                <li><a class="nav__link" href="../lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="../lineage.html">One family</a></li>
                 <li><a class="nav__link" href="../genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="../culture.html">Culture</a></li>
                 <li><a class="nav__link" href="../research.html" aria-current="page">Research</a></li>
@@ -174,7 +174,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="../lineage.html">The two lines</a></li>
+                        <li><a href="../lineage.html">One family</a></li>
                         <li><a href="../genetics.html">DNA and haplogroups</a></li>
                         <li><a href="../research.html">Papers and sources</a></li>
                         <li><a href="../limitations.html">What this cannot show</a></li>
@@ -196,7 +196,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/research/punic-genetic-diversity-2025.html
+++ b/research/punic-genetic-diversity-2025.html
@@ -84,7 +84,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="../index.html">Home</a></li>
-                <li><a class="nav__link" href="../lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="../lineage.html">One family</a></li>
                 <li><a class="nav__link" href="../genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="../culture.html">Culture</a></li>
                 <li><a class="nav__link" href="../research.html" aria-current="page">Research</a></li>
@@ -172,7 +172,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="../lineage.html">The two lines</a></li>
+                        <li><a href="../lineage.html">One family</a></li>
                         <li><a href="../genetics.html">DNA and haplogroups</a></li>
                         <li><a href="../research.html">Papers and sources</a></li>
                         <li><a href="../limitations.html">What this cannot show</a></li>
@@ -194,7 +194,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,7 +6,7 @@
   <!-- Homepage -->
   <url>
     <loc>https://northafricanorigins.com/</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
     <image:image>
@@ -19,7 +19,7 @@
   <!-- Start Here Page -->
   <url>
     <loc>https://northafricanorigins.com/start-here.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.85</priority>
     <image:image>
@@ -32,7 +32,7 @@
   <!-- Glossary Page -->
   <url>
     <loc>https://northafricanorigins.com/glossary.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -63,7 +63,7 @@
   <!-- Genetics Revolution Page -->
   <url>
     <loc>https://northafricanorigins.com/genetics.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -76,7 +76,7 @@
   <!-- Cultural Heritage Page -->
   <url>
     <loc>https://northafricanorigins.com/culture.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -176,7 +176,7 @@
   <!-- Maps & Sites Page -->
   <url>
     <loc>https://northafricanorigins.com/maps-sites.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -184,14 +184,14 @@
   <!-- Contact Page -->
   <url>
     <loc>https://northafricanorigins.com/contact.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   
   <url>
     <loc>https://northafricanorigins.com/limitations.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-10</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/start-here.html
+++ b/start-here.html
@@ -58,7 +58,7 @@
       "name": "Start here | North African Origins",
       "url": "https://northafricanorigins.com/start-here.html",
       "inLanguage": "en",
-      "dateModified": "2026-09-07"
+      "dateModified": "2026-09-10"
     }
     </script>
 </head>
@@ -83,7 +83,7 @@
         <div class="container">
             <ul class="nav__list">
                 <li><a class="nav__link" href="index.html" aria-current="page">Home</a></li>
-                <li><a class="nav__link" href="lineage.html">The two lines</a></li>
+                <li><a class="nav__link" href="lineage.html">One family</a></li>
                 <li><a class="nav__link" href="genetics.html">DNA</a></li>
                 <li><a class="nav__link" href="culture.html">Culture</a></li>
                 <li><a class="nav__link" href="research.html">Research</a></li>
@@ -117,10 +117,11 @@
                     <div class="block block--sea">
                         <span class="kicker">Route 1 &middot; 15 min</span>
                         <h3>You are new to DNA</h3>
-                        <p>Concepts first, then this family's results.</p>
+                        <p>Concepts first, then the big picture, then one family.</p>
                         <ol>
                             <li><a href="genetics.html">What a haplogroup is</a>, and why two of them is not an ancestry</li>
-                            <li><a href="lineage.html">The two lines</a> — the evidence itself</li>
+                            <li><a href="index.html">How North Africa was made</a>, the big picture</li>
+                            <li><a href="lineage.html">One family</a>, one real case</li>
                             <li><a href="limitations.html">What it cannot show</a></li>
                         </ol>
                     </div>
@@ -129,9 +130,9 @@
                         <h3>You want the papers</h3>
                         <p>Published evidence first, interpretation second.</p>
                         <ol>
-                            <li><a href="research.html">Twelve paper summaries</a>, newest first</li>
+                            <li><a href="research.html">Thirteen paper summaries</a>, newest first</li>
                             <li>Start with the Green Sahara ancient DNA study</li>
-                            <li><a href="lineage.html">The two lines</a>, where they are synthesised</li>
+                            <li><a href="index.html">How North Africa was made</a>, where they are put together</li>
                         </ol>
                     </div>
                     <div class="block block--mountain">
@@ -141,7 +142,7 @@
                         <ol>
                             <li><a href="culture.html">Culture and language</a> of the Souss</li>
                             <li><a href="maps-sites.html">Maps and sites</a> — where all this happened</li>
-                            <li><a href="lineage.html">The two lines</a>, for the genetic context</li>
+                            <li><a href="lineage.html">One family</a>, for the genetic side of the Souss</li>
                         </ol>
                     </div>
                 </div>
@@ -152,14 +153,14 @@
             <div class="container">
                 <div class="note">
                     <h2 id="shortest" class="mt-0">Or just read one page</h2>
-                    <p class="mb-0">If you only want the gist, <a href="index.html">the homepage</a> carries it in about ninety seconds. Come back here when you want to go deeper.</p>
+                    <p class="mb-0">If you only want the gist, <a href="index.html">the homepage</a> carries it in a few minutes. Come back here when you want to go deeper.</p>
                 </div>
             </div>
         </section>
 
         <section class="band band--tight">
             <div class="container">
-                <p class="page-updated">Last updated: 7 September 2026</p>
+                <p class="page-updated">Last updated: 10 September 2026</p>
             </div>
         </section>
 
@@ -173,7 +174,7 @@
                 <div>
                     <h2>The research</h2>
                     <ul>
-                        <li><a href="lineage.html">The two lines</a></li>
+                        <li><a href="lineage.html">One family</a></li>
                         <li><a href="genetics.html">DNA and haplogroups</a></li>
                         <li><a href="research.html">Papers and sources</a></li>
                         <li><a href="limitations.html">What this cannot show</a></li>
@@ -195,7 +196,7 @@
                     </ul>
                 </div>
             </div>
-            <p class="site-footer__base">North African Origins — an independent, non-commercial record of one Amazigh lineage from Souss-Massa, Morocco. Claims are cited to published literature; where they are not, the page says so.</p>
+            <p class="site-footer__base">North African Origins — an independent, non-commercial account of how migrations shaped North Africa&rsquo;s population, with one Amazigh family from Souss-Massa, Morocco, as a worked example. Claims are cited to published literature; where they are not, the page says so.</p>
         </div>
     </footer>
 </body>


### PR DESCRIPTION
## What

The site is called North African Origins, but its homepage was entirely one family's two haplogroups. This PR leads with the region instead and gives the family case its own tab.

**Homepage (`index.html`)**
- **"How North Africa was made":** an authored SVG schematic of which ancestries arrived and which left. Solid yaz arrows mark arrivals: farmers from Iberia and the Levant, Arab ancestry, and two sub-Saharan waves. Dashed arrows mark departures, to the Canaries and to Sicily/Ibiza. The Green Sahara stands alone because it was isolated. Every arrow is labelled with its date range, so colour is never the only cue.
- **Numbers:** 20,000+ years of roots, farmers 7.5–5k years ago, 2 sub-Saharan waves, and the paper count.
- **"The layers, in order":** eleven dated steps, from roots more than 20,000 years deep to the Middle Ages, using the existing `.eras` component. Each step cites and links its paper's summary. **Nothing comes from outside the site's own summaries,** and the ranges and hedges are kept.
- **"What these papers do not cover yet":** the Roman to Byzantine centuries, ancient DNA from the Arab conquest, and ancient Egypt are named as gaps rather than filled from memory.
- **Doors:** One family, DNA, Research.
- **Head:** new title (50 chars), description (158) and social cards aimed at North African ancestry. The geo tags that pinned the homepage to Souss-Massa are removed.

**One family (`lineage.html`)**, same URL, so the FR/AR versions and every link still work:
- The nav label is now "One family", and the heading is "One family, two lines".
- It opens by linking back to the homepage story, and carries the family's key figures (65,000+, ~400 BCE, 8–11k) that used to be on the homepage.

**Everywhere else**
- **Nav, footer and body links:** the nav and footer on all 23 English pages now say "One family", and the footer line now describes the region-wide scope. Start here, the glossary, the limitations page and two findings on the research page are updated to match.
- **Documentation:** `DESIGN.md` (the site's purpose, plus the new rule that migration arrows are yaz, solid for in and dashed for out), `CLAUDE.md`, and the scout's `PROMPT.md`. Relevance paragraphs now place a paper in the regional story first, then say whether it bears on the family case.

**Fixed**
- **Stale counts:** the homepage said 11 papers and Start here said twelve; there are thirteen.
- **Scout sync:** `scout.py` now keeps both in step. It matches numerals as well as number words, `index.html` and `start-here.html` are on its allowlist, and the homepage's sitemap entry (`/`) gets its `lastmod` bumped.

The French and Arabic homepages are not in this PR. They still tell the family story, and they get translated from this text once it is approved.

## Checked

- `scout.py validate` passes: 13 papers, and "thirteen"/"13" everywhere it is written, including the homepage stat and Start here.
- The nav and footer hash identically across all 23 English pages (ignoring `aria-current`), and no "The two lines" label is left in English.
- Homepage prose is about 630 words, against the ~900 limit.
- No horizontal overflow at 320, 390 or 1280px on `index.html` or `lineage.html`, measured in same-origin iframes.
- Lighthouse, mobile: accessibility, best practices and SEO are **100** on both pages.
- "Last updated", `dateModified` and sitemap `lastmod` are bumped on every page touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015t4mnrJt1QGKZ56brKvpeh

## Verification

- Tokens - total: 0 (implementation: unavailable + git-flow: 0)

Closes #91