### PR TITLE
feat(home): show the family's two lines as one sample in the regional story

### DIFF
--- a/changelog/unreleased/feat-home-family-sample.md
+++ b/changelog/unreleased/feat-home-family-sample.md
@@ -1,0 +1,2 @@
+### Added
+- The homepage has a "Where one family fits" section after the timeline. It places the family's two DNA lines in the regional layers as one sample: the father's line E-PF2546 as a branch of E-M81, the region's most common Y-chromosome, and the mother's line H1-T16189C! from the H1 branch that came from Europe. Each claim cites a paper summarised on the site, the section links to the timeline steps and the family page, and the hero links down to it (#93)

--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
                             <a class="btn btn--ghost" href="start-here.html">New here? Start here</a>
                         </div>
                     </div>
-                    <p class="lead">North Africans are not one people who arrived once. They are layers: deep local roots, joined again and again by farmers, traders and travellers, and sending people out across the sea in turn.</p>
+                    <p class="lead">North Africans are not one people who arrived once. They are layers: deep local roots, joined again and again by farmers, traders and travellers, and sending people out across the sea in turn. <a href="#sample">One family from the Souss valley</a> shows how those layers meet in a single household.</p>
                 </div>
             </div>
         </section>
@@ -263,7 +263,7 @@
                             <p class="era__note">The same Maghrebi forager profile ran from Morocco to Algeria and Tunisia for thousands of years. Around 8,000 years ago, one person in Tunisia already carried ancestry related to European hunter-gatherers (<a href="research/eastern-maghreb-neolithic-continuity-2025.html">Lipson et al. 2025</a>).</p>
                         </div>
                     </li>
-                    <li class="era">
+                    <li class="era" id="layer-farming">
                         <span class="era__when">About 7,500–5,000 years ago</span>
                         <div>
                             <h3 class="era__what">Farming arrives with people</h3>
@@ -277,14 +277,14 @@
                             <p class="era__note">Genomes from Takarkori, in Libya, date to a time when the Sahara was grassland. They carry a previously unknown, deeply divergent lineage from a population that was largely isolated from its neighbours (<a href="research/green-sahara-ancient-dna-2025.html">Salem et al. 2025</a>).</p>
                         </div>
                     </li>
-                    <li class="era">
+                    <li class="era" id="layer-women">
                         <span class="era__when">Late Pleistocene to recent times</span>
                         <div>
                             <h3 class="era__what">Women's lines, in waves</h3>
                             <p class="era__note">Complete mitochondrial genomes show several waves of female-mediated movement shaping the region (<a href="research/north-african-mitogenomes-2025.html">Colombo et al. 2025</a>), on top of a maternal core so shared that populations across the Maghreb differ only slightly from one another (<a href="research/north-africa-maternal-diversity-2026.html">Boumajdi et al. 2026</a>).</p>
                         </div>
                     </li>
-                    <li class="era">
+                    <li class="era" id="layer-em81">
                         <span class="era__when">About 2,000–3,000 years ago</span>
                         <div>
                             <h3 class="era__what">One father's line spreads fast</h3>
@@ -320,6 +320,33 @@
                         </div>
                     </li>
                 </ul>
+            </div>
+        </section>
+
+        <!-- One sample -->
+        <section class="band" aria-labelledby="sample">
+            <div class="container">
+                <span class="kicker">One sample</span>
+                <h2 id="sample">Where one family fits</h2>
+                <p class="prose">Every North African carries these layers in a different mix. Here is one real sample: an Amazigh (Berber) family from Souss-Massa, Morocco, read through the two DNA lines that pass down almost unchanged, father to son and mother to child.</p>
+
+                <div class="split">
+                    <div class="block block--sea">
+                        <h3>The father's line: <span class="hg">E-PF2546</span></h3>
+                        <p>A branch of <span class="hg">E-M81</span>, still the most common Y-chromosome in Morocco, Algeria and Tunisia (<a href="research/north-africa-maternal-diversity-2026.html">Boumajdi et al. 2026</a>). <span class="hg">E-M81</span> grew from a small founding group that spread fast about 2,000–3,000 years ago (<a href="research/e-m183-recent-origin-2018.html">Solé-Morata et al. 2017</a>).</p>
+                        <p class="mb-0"><b>In the timeline:</b> <a href="#layer-em81">One father's line spreads fast</a></p>
+                    </div>
+                    <div class="block block--yaz">
+                        <h3>The mother's line: <span class="hg">H1-T16189C!</span></h3>
+                        <p>Haplogroup H is one of the three main maternal groups in North Africa today (<a href="research/north-africa-maternal-diversity-2026.html">Boumajdi et al. 2026</a>). Its H1 branch came from Europe. When is debated: mitochondrial dating points to the early Holocene (<a href="research/north-african-mitogenomes-2025.html">Colombo et al. 2025</a>), and the best-supported route is with the farmers who crossed from Iberia (<a href="research/neolithic-iberia-morocco-2023.html">Villalba-Mouco et al. 2023</a>).</p>
+                        <p class="mb-0"><b>In the timeline:</b> <a href="#layer-farming">Farming arrives with people</a> and <a href="#layer-women">Women's lines, in waves</a></p>
+                    </div>
+                </div>
+
+                <div class="stack" style="margin-top: var(--gap)">
+                    <p class="prose">An African father's line beside a mother's line from Europe is not a contradiction. It is the regional pattern these studies describe: a local father-line that is still the most common, and women's lines arriving in waves. It is still only a sample: two ancestors out of more than a thousand, and a haplogroup is not an ethnicity. <a href="lineage.html#limits">What this sample cannot show</a>.</p>
+                    <p><a class="btn" href="lineage.html">Read the family's full story</a></p>
+                </div>
             </div>
         </section>
 


### PR DESCRIPTION
## What

Since #92 the homepage tells the region-wide story, and the family's two haplogroups appeared only on the "One family" page. This PR puts them back on the homepage as **one real sample** inside that story.

**New section "Where one family fits"** (`#sample`), after the timeline:
- **The father's line (sea block), `E-PF2546`:** a branch of `E-M81`, still the most common Y-chromosome in Morocco, Algeria and Tunisia (Boumajdi et al. 2026). E-M81 grew from a small founding group that spread fast about 2,000–3,000 years ago (Solé-Morata et al. 2017).
- **The mother's line (yaz block), `H1-T16189C!`:** H is one of the three main maternal groups in North Africa today (Boumajdi et al. 2026), and its H1 branch came from Europe. The timing is given as debated: mitochondrial dating points to the early Holocene (Colombo et al. 2025), and the best-supported route is the farmers' crossing from Iberia (Villalba-Mouco et al. 2023). The section does not pick one number; the family page weighs the dates.
- **Links into the timeline:** each block links to the steps it belongs to. `id`s were added to three `.era` items: `#layer-em81`, `#layer-farming` and `#layer-women`.
- **Why the two lines don't match, and the limit:** one paragraph says an African father's line beside a European-origin mother's line is the regional pattern, not a contradiction. It then says this is one sample, two ancestors out of more than a thousand, and that a haplogroup is not an ethnicity. It links to `lineage.html#limits`, and a button goes to the full family page.
- **Hero:** the lead now ends with a link down to the section, so it can be found from the top of the page.

**Sourcing:** every claim in the section cites a paper already summarised in `research/`, which keeps the homepage rule intact. The figures that come from outside those summaries stay on the family page with their own sources: 65,000+, ~400 BCE (FamilyTreeDNA/YFull), the E-M81 percentages, and 42% of H.

**No CSS or design changes.** The section uses existing components (`.split`, `.block--sea`, `.block--yaz`, `.hg`, `.btn`), and the father's line stays sea and the mother's line stays yaz, as everywhere else. The band sequence is sunk → paper → sand, with no repeated ground.

The French and Arabic homepages still need both this and #92 translated. That is the follow-up PR.

## Checked

- `scout.py validate --offline` passes: 13 papers, "thirteen" everywhere.
- Homepage paragraph prose is about 800 words, up from 560 and still under the ~900 limit.
- Every in-page anchor resolves, there are no duplicate ids, and every link to `research/` and `lineage.html#limits` exists.
- No horizontal overflow at 320, 390, 640 or 1280px. 640 is included because `.hg` does not wrap, and the block headings carry `H1-T16189C!`.
- Lighthouse, mobile, on `index.html`: accessibility, best practices and SEO are 100, and performance is 99.
- "Last updated", `dateModified` and sitemap `lastmod` are already 10 September 2026, so there was nothing to bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015t4mnrJt1QGKZ56brKvpeh

## Verification

- Tokens - total: 0 (implementation: unavailable + git-flow: 0)

Closes #93