### PR TITLE
fix(seo): research pages describe a summary based on the paper, not the paper itself

### DIFF
--- a/.github/research-scout/scout.py
+++ b/.github/research-scout/scout.py
@@ -422,6 +422,39 @@ def render_item(c: dict, k: dict, file: str) -> str:
         '\n                    </li>')
 
 
+ORG = {"@type": "Organization", "name": "North African Origins", "url": f"{SITE}/",
+       "logo": {"@type": "ImageObject", "url": f"{SITE}/icon-512x512.png"}}
+
+
+def article_ld(url: str, headline: str, description: str, published: str, modified: str,
+               paper: dict) -> str:
+    """JSON-LD for a research page. The page is this site's summary (an Article) based on
+    the paper (a ScholarlyArticle); it must never present itself as the paper."""
+    doi_url = f"https://doi.org/{paper['doi']}"
+    ld = {"@context": "https://schema.org", "@type": "Article",
+          "headline": headline, "description": description,
+          "url": url, "mainEntityOfPage": url, "inLanguage": "en",
+          "datePublished": published, "dateModified": modified,
+          "author": ORG, "publisher": ORG,
+          "isBasedOn": {"@type": "ScholarlyArticle", "@id": doi_url, "headline": paper["title"],
+                        "datePublished": paper["date"],
+                        "isPartOf": {"@type": "Periodical", "name": paper["journal"]},
+                        "identifier": {"@type": "PropertyValue", "propertyID": "DOI",
+                                       "value": paper["doi"]},
+                        "sameAs": doi_url},
+          "citation": paper["citation"]}
+    text = json.dumps(ld, indent=2, ensure_ascii=False).replace("</", "<\\/")
+    return '<script type="application/ld+json">\n' + textwrap.indent(text, "    ") + "\n    </script>"
+
+
+def page_ld(page: str) -> dict | None:
+    m = re.search(r'<script type="application/ld\+json">(.*?)</script>', page, re.S)
+    try:
+        return json.loads(m.group(1)) if m else None
+    except json.JSONDecodeError:
+        return None
+
+
 def render_page(c: dict, k: dict, file: str, today: dt.date, base: str, count: int) -> str:
     """Build a new article on top of an existing one, so header, nav and footer are
     always the site's current chrome rather than a copy that can drift."""
@@ -444,11 +477,9 @@ def render_page(c: dict, k: dict, file: str, today: dt.date, base: str, count: i
         "updated_long": long_date(str(today)),
     }
     main = re.sub(r"\{\{(\w+)\}\}", lambda m: values[m.group(1)], main)
-    ld = json.dumps({"@context": "https://schema.org", "@type": "ScholarlyArticle",
-                     "headline": c["title"], "url": url, "inLanguage": "en",
-                     "datePublished": c["date"], "dateModified": str(today),
-                     "sameAs": f"https://doi.org/{c['doi']}"}, indent=2, ensure_ascii=False)
-    ld = '<script type="application/ld+json">\n' + textwrap.indent(ld.replace("</", "<\\/"), "    ") + "\n    </script>"
+    ld = article_ld(url, k["list_title"], k["description"], str(today), str(today),
+                    {"doi": c["doi"], "title": c["title"], "date": c["date"],
+                     "journal": c["journal"], "citation": citation(c)})
     swaps = [
         (r"<title>.*?</title>", f"<title>{e(head_title)}</title>"),
         (r'<meta name="description" content="[^"]*">', f'<meta name="description" content="{a(k["description"])}">'),
@@ -668,12 +699,15 @@ def cmd_validate(args) -> None:
         kicker = re.search(r'class="kicker"><time datetime="([^"]+)">[^<]+</time> &middot; ([^<]+)</span>', page)
         if not kicker or kicker.group(1) != x["date"] or norm_journal(kicker.group(2)) != norm_journal(x["journal"]):
             errors.append(f"{x['href']}: kicker date/journal does not match research.html")
-        published = re.search(r'"datePublished": "([^"]+)"', page)
-        if not published or published.group(1) != x["date"]:
-            errors.append(f"{x['href']}: JSON-LD datePublished does not match research.html")
-        same = re.search(r'"sameAs": "https://doi\.org/([^"]+)"', page)
-        if not same or same.group(1).lower() != x["doi"]:
-            errors.append(f"{x['href']}: JSON-LD sameAs is not the listed DOI")
+        ld = page_ld(page)
+        paper = ld.get("isBasedOn") if isinstance(ld, dict) else None
+        if not isinstance(paper, dict):
+            errors.append(f"{x['href']}: JSON-LD is missing, invalid, or has no isBasedOn paper")
+        else:
+            if paper.get("datePublished") != x["date"]:
+                errors.append(f"{x['href']}: JSON-LD paper date does not match research.html")
+            if str(paper.get("sameAs", "")).lower() != f"https://doi.org/{x['doi']}":
+                errors.append(f"{x['href']}: JSON-LD paper DOI is not the listed DOI")
         for section in ("summary", "takeaways", "relevance"):
             if f'id="{section}"' not in page:
                 errors.append(f"{x['href']}: missing the #{section} section")

--- a/changelog/unreleased/fix-research-jsonld.md
+++ b/changelog/unreleased/fix-research-jsonld.md
@@ -1,0 +1,2 @@
+### Fixed
+- Each research page's structured data described the page as if it were the paper itself (the paper's title, date and DOI as the page's own). It now describes what the page is: this site's summary, based on the paper, with the paper's title, publication date, journal, DOI and full citation nested inside. Search engines and AI agents can tell the summary from the source and cite the source. The research scout writes new pages the same way, and its validation reads the paper's date and DOI from there (#97)

--- a/research/amazigh-genomic-heterogeneity-2024.html
+++ b/research/amazigh-genomic-heterogeneity-2024.html
@@ -53,13 +53,49 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ScholarlyArticle",
-      "headline": "Understanding the Genomic Heterogeneity of North African Imazighen: From Broad to Microgeographical Perspectives",
+      "@type": "Article",
+      "headline": "Amazigh genomic heterogeneity, village by village",
+      "description": "Summary of Vilà-Valls et al. 2024 Scientific Reports study: the largest Amazigh genomic dataset reveals microgeographical diversity, two trans-Saharan admixture waves, and deep Epipaleolithic roots.",
       "url": "https://northafricanorigins.com/research/amazigh-genomic-heterogeneity-2024.html",
+      "mainEntityOfPage": "https://northafricanorigins.com/research/amazigh-genomic-heterogeneity-2024.html",
       "inLanguage": "en",
-      "datePublished": "2024-05-01",
+      "datePublished": "2026-04-24",
       "dateModified": "2026-09-10",
-      "sameAs": "https://doi.org/10.1038/s41598-024-60568-8"
+      "author": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "isBasedOn": {
+        "@type": "ScholarlyArticle",
+        "@id": "https://doi.org/10.1038/s41598-024-60568-8",
+        "headline": "Understanding the Genomic Heterogeneity of North African Imazighen: From Broad to Microgeographical Perspectives",
+        "datePublished": "2024-05-01",
+        "isPartOf": {
+          "@type": "Periodical",
+          "name": "Scientific Reports"
+        },
+        "identifier": {
+          "@type": "PropertyValue",
+          "propertyID": "DOI",
+          "value": "10.1038/s41598-024-60568-8"
+        },
+        "sameAs": "https://doi.org/10.1038/s41598-024-60568-8"
+      },
+      "citation": "Vilà-Valls, L., Abdeli, A., Lucas-Sánchez, M., Bekada, A., Calafell, F., Benhassine, T., & Comas, D. (2024). Scientific Reports, 14(1), 9979."
     }
     </script>
 </head>

--- a/research/canary-islanders-exome-ancestry-2026.html
+++ b/research/canary-islanders-exome-ancestry-2026.html
@@ -53,13 +53,49 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ScholarlyArticle",
-      "headline": "Expanding CIRdb, a comprehensive catalog of whole-exome sequencing data of Canary Islanders",
+      "@type": "Article",
+      "headline": "A shared selection signal links Canary Islanders and North Africa",
+      "description": "A whole-exome study of Canary Islanders maps their European, North African and sub-Saharan ancestry and a selection signal shared with North Africa.",
       "url": "https://northafricanorigins.com/research/canary-islanders-exome-ancestry-2026.html",
+      "mainEntityOfPage": "https://northafricanorigins.com/research/canary-islanders-exome-ancestry-2026.html",
       "inLanguage": "en",
-      "datePublished": "2026-08",
+      "datePublished": "2026-09-10",
       "dateModified": "2026-09-10",
-      "sameAs": "https://doi.org/10.1016/j.isci.2026.117146"
+      "author": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "isBasedOn": {
+        "@type": "ScholarlyArticle",
+        "@id": "https://doi.org/10.1016/j.isci.2026.117146",
+        "headline": "Expanding CIRdb, a comprehensive catalog of whole-exome sequencing data of Canary Islanders",
+        "datePublished": "2026-08",
+        "isPartOf": {
+          "@type": "Periodical",
+          "name": "iScience"
+        },
+        "identifier": {
+          "@type": "PropertyValue",
+          "propertyID": "DOI",
+          "value": "10.1016/j.isci.2026.117146"
+        },
+        "sameAs": "https://doi.org/10.1016/j.isci.2026.117146"
+      },
+      "citation": "Díaz-de Usera, A. et al. (2026). iScience, 29, 117146."
     }
     </script>
 </head>

--- a/research/canary-islands-amazigh-history-2025.html
+++ b/research/canary-islands-amazigh-history-2025.html
@@ -53,13 +53,49 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ScholarlyArticle",
-      "headline": "Climate, Biogeography, and Human Resilience in the Demographic History of the Canary Islands During the Amazigh Period",
+      "@type": "Article",
+      "headline": "The Guanches before European contact",
+      "description": "Summary of Santana et al. 2025 (Scientific Reports): Demographic history and resilience of the Guanches (indigenous Canarian Amazighs) prior to European colonization.",
       "url": "https://northafricanorigins.com/research/canary-islands-amazigh-history-2025.html",
+      "mainEntityOfPage": "https://northafricanorigins.com/research/canary-islands-amazigh-history-2025.html",
       "inLanguage": "en",
-      "datePublished": "2025-06-03",
+      "datePublished": "2026-09-06",
       "dateModified": "2026-09-10",
-      "sameAs": "https://doi.org/10.1038/s41598-025-04302-y"
+      "author": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "isBasedOn": {
+        "@type": "ScholarlyArticle",
+        "@id": "https://doi.org/10.1038/s41598-025-04302-y",
+        "headline": "Climate, Biogeography, and Human Resilience in the Demographic History of the Canary Islands During the Amazigh Period",
+        "datePublished": "2025-06-03",
+        "isPartOf": {
+          "@type": "Periodical",
+          "name": "Scientific Reports"
+        },
+        "identifier": {
+          "@type": "PropertyValue",
+          "propertyID": "DOI",
+          "value": "10.1038/s41598-025-04302-y"
+        },
+        "sameAs": "https://doi.org/10.1038/s41598-025-04302-y"
+      },
+      "citation": "Santana, J. et al. (2025). Scientific Reports, 15, 4302."
     }
     </script>
 </head>

--- a/research/e-m183-recent-origin-2018.html
+++ b/research/e-m183-recent-origin-2018.html
@@ -53,13 +53,49 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ScholarlyArticle",
-      "headline": "Whole Y-Chromosome Sequences Reveal an Extremely Recent Origin of E-M183",
+      "@type": "Article",
+      "headline": "E-M81 is far younger than anyone expected",
+      "description": "Summary of Solé-Morata et al. 2017: whole Y-chromosome sequencing dates E-M81/E-M183 TMRCA to ~2,000-3,000 years ago with star-like expansion pattern.",
       "url": "https://northafricanorigins.com/research/e-m183-recent-origin-2018.html",
+      "mainEntityOfPage": "https://northafricanorigins.com/research/e-m183-recent-origin-2018.html",
       "inLanguage": "en",
-      "datePublished": "2017-11-21",
+      "datePublished": "2026-02-13",
       "dateModified": "2026-09-10",
-      "sameAs": "https://doi.org/10.1038/s41598-017-16271-y"
+      "author": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "isBasedOn": {
+        "@type": "ScholarlyArticle",
+        "@id": "https://doi.org/10.1038/s41598-017-16271-y",
+        "headline": "Whole Y-Chromosome Sequences Reveal an Extremely Recent Origin of E-M183",
+        "datePublished": "2017-11-21",
+        "isPartOf": {
+          "@type": "Periodical",
+          "name": "Scientific Reports"
+        },
+        "identifier": {
+          "@type": "PropertyValue",
+          "propertyID": "DOI",
+          "value": "10.1038/s41598-017-16271-y"
+        },
+        "sameAs": "https://doi.org/10.1038/s41598-017-16271-y"
+      },
+      "citation": "Solé-Morata, N. et al. (2017). Scientific Reports, 7, 15941."
     }
     </script>
 </head>

--- a/research/eastern-maghreb-neolithic-continuity-2025.html
+++ b/research/eastern-maghreb-neolithic-continuity-2025.html
@@ -53,13 +53,49 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ScholarlyArticle",
-      "headline": "High Continuity of Forager Ancestry in the Neolithic Period of the Eastern Maghreb",
+      "@type": "Article",
+      "headline": "The eastern Maghreb kept its foragers",
+      "description": "Summary of Lipson et al. 2025 (Nature): ancient DNA from Algeria and Tunisia shows strong forager ancestry continuity in the eastern Maghreb during the Neolithic transition.",
       "url": "https://northafricanorigins.com/research/eastern-maghreb-neolithic-continuity-2025.html",
+      "mainEntityOfPage": "https://northafricanorigins.com/research/eastern-maghreb-neolithic-continuity-2025.html",
       "inLanguage": "en",
-      "datePublished": "2025-03-12",
+      "datePublished": "2026-07-09",
       "dateModified": "2026-09-10",
-      "sameAs": "https://doi.org/10.1038/s41586-025-08699-4"
+      "author": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "isBasedOn": {
+        "@type": "ScholarlyArticle",
+        "@id": "https://doi.org/10.1038/s41586-025-08699-4",
+        "headline": "High Continuity of Forager Ancestry in the Neolithic Period of the Eastern Maghreb",
+        "datePublished": "2025-03-12",
+        "isPartOf": {
+          "@type": "Periodical",
+          "name": "Nature"
+        },
+        "identifier": {
+          "@type": "PropertyValue",
+          "propertyID": "DOI",
+          "value": "10.1038/s41586-025-08699-4"
+        },
+        "sameAs": "https://doi.org/10.1038/s41586-025-08699-4"
+      },
+      "citation": "Lipson, M. et al. (2025). Nature, 641, 925-931."
     }
     </script>
 </head>

--- a/research/green-sahara-ancient-dna-2025.html
+++ b/research/green-sahara-ancient-dna-2025.html
@@ -53,13 +53,49 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ScholarlyArticle",
-      "headline": "Ancient DNA from the Green Sahara Reveals Ancestral North African Lineage",
+      "@type": "Article",
+      "headline": "Ancient DNA from the Green Sahara",
+      "description": "Summary of Salem et al. 2025 Nature study: ancient DNA from Green Sahara Libya reveals basal North African lineage and population dynamics ~7,000 years ago.",
       "url": "https://northafricanorigins.com/research/green-sahara-ancient-dna-2025.html",
+      "mainEntityOfPage": "https://northafricanorigins.com/research/green-sahara-ancient-dna-2025.html",
       "inLanguage": "en",
-      "datePublished": "2025-04-02",
+      "datePublished": "2026-02-13",
       "dateModified": "2026-09-10",
-      "sameAs": "https://doi.org/10.1038/s41586-025-08793-7"
+      "author": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "isBasedOn": {
+        "@type": "ScholarlyArticle",
+        "@id": "https://doi.org/10.1038/s41586-025-08793-7",
+        "headline": "Ancient DNA from the Green Sahara Reveals Ancestral North African Lineage",
+        "datePublished": "2025-04-02",
+        "isPartOf": {
+          "@type": "Periodical",
+          "name": "Nature"
+        },
+        "identifier": {
+          "@type": "PropertyValue",
+          "propertyID": "DOI",
+          "value": "10.1038/s41586-025-08793-7"
+        },
+        "sameAs": "https://doi.org/10.1038/s41586-025-08793-7"
+      },
+      "citation": "Salem, T. et al. (2025). Nature, 641, 144–150."
     }
     </script>
 </head>

--- a/research/medieval-sicily-north-african-ancestry-2026.html
+++ b/research/medieval-sicily-north-african-ancestry-2026.html
@@ -53,13 +53,49 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ScholarlyArticle",
-      "headline": "Genetic histories of individuals from multi-faith medieval Sicily",
+      "@type": "Article",
+      "headline": "North African ancestry in Sicily before the Islamic conquest",
+      "description": "Ancient DNA from 111 medieval Sicilians finds substantial North African ancestry in burials from before the island's Islamic conquest.",
       "url": "https://northafricanorigins.com/research/medieval-sicily-north-african-ancestry-2026.html",
+      "mainEntityOfPage": "https://northafricanorigins.com/research/medieval-sicily-north-african-ancestry-2026.html",
       "inLanguage": "en",
-      "datePublished": "2026-06-24",
+      "datePublished": "2026-09-10",
       "dateModified": "2026-09-10",
-      "sameAs": "https://doi.org/10.1371/journal.pone.0350298"
+      "author": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "isBasedOn": {
+        "@type": "ScholarlyArticle",
+        "@id": "https://doi.org/10.1371/journal.pone.0350298",
+        "headline": "Genetic histories of individuals from multi-faith medieval Sicily",
+        "datePublished": "2026-06-24",
+        "isPartOf": {
+          "@type": "Periodical",
+          "name": "PLOS One"
+        },
+        "identifier": {
+          "@type": "PropertyValue",
+          "propertyID": "DOI",
+          "value": "10.1371/journal.pone.0350298"
+        },
+        "sameAs": "https://doi.org/10.1371/journal.pone.0350298"
+      },
+      "citation": "Monnereau, A. et al. (2026). PLOS One, 21, e0350298."
     }
     </script>
 </head>

--- a/research/mediterranean-islamic-dna-ibiza-2026.html
+++ b/research/mediterranean-islamic-dna-ibiza-2026.html
@@ -53,13 +53,49 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ScholarlyArticle",
-      "headline": "Analysis of Medieval Burials from Ibiza Reveals Genetic and Pathogenic Diversity During the Islamic Period",
+      "@type": "Article",
+      "headline": "Islamic-period Ibiza reveals North African gene flow",
+      "description": "Summary of Rodríguez-Varela et al. 2026 (Nature Communications): Ancient genomes from medieval Ibiza (950-1150 CE) reveal North African gene flow during the Umayyad and Almoravid periods.",
       "url": "https://northafricanorigins.com/research/mediterranean-islamic-dna-ibiza-2026.html",
+      "mainEntityOfPage": "https://northafricanorigins.com/research/mediterranean-islamic-dna-ibiza-2026.html",
       "inLanguage": "en",
-      "datePublished": "2026-03-26",
+      "datePublished": "2026-09-06",
       "dateModified": "2026-09-10",
-      "sameAs": "https://doi.org/10.1038/s41467-026-70615-9"
+      "author": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "isBasedOn": {
+        "@type": "ScholarlyArticle",
+        "@id": "https://doi.org/10.1038/s41467-026-70615-9",
+        "headline": "Analysis of Medieval Burials from Ibiza Reveals Genetic and Pathogenic Diversity During the Islamic Period",
+        "datePublished": "2026-03-26",
+        "isPartOf": {
+          "@type": "Periodical",
+          "name": "Nature Communications"
+        },
+        "identifier": {
+          "@type": "PropertyValue",
+          "propertyID": "DOI",
+          "value": "10.1038/s41467-026-70615-9"
+        },
+        "sameAs": "https://doi.org/10.1038/s41467-026-70615-9"
+      },
+      "citation": "Rodríguez-Varela, R. et al. (2026). Nature Communications, 17, 70615."
     }
     </script>
 </head>

--- a/research/neolithic-iberia-morocco-2023.html
+++ b/research/neolithic-iberia-morocco-2023.html
@@ -53,13 +53,49 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ScholarlyArticle",
-      "headline": "Northwest African Neolithic Initiated by Migrants from Iberia and Levant",
+      "@type": "Article",
+      "headline": "The Maghreb Neolithic began with migrants from Iberia",
+      "description": "Summary of Villalba-Mouco et al. 2023 Nature study: ancient DNA from Neolithic Morocco confirms trans-Gibraltar migration from Iberia and Levant.",
       "url": "https://northafricanorigins.com/research/neolithic-iberia-morocco-2023.html",
+      "mainEntityOfPage": "https://northafricanorigins.com/research/neolithic-iberia-morocco-2023.html",
       "inLanguage": "en",
-      "datePublished": "2023-06-07",
+      "datePublished": "2026-02-13",
       "dateModified": "2026-09-10",
-      "sameAs": "https://doi.org/10.1038/s41586-023-06166-6"
+      "author": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "isBasedOn": {
+        "@type": "ScholarlyArticle",
+        "@id": "https://doi.org/10.1038/s41586-023-06166-6",
+        "headline": "Northwest African Neolithic Initiated by Migrants from Iberia and Levant",
+        "datePublished": "2023-06-07",
+        "isPartOf": {
+          "@type": "Periodical",
+          "name": "Nature"
+        },
+        "identifier": {
+          "@type": "PropertyValue",
+          "propertyID": "DOI",
+          "value": "10.1038/s41586-023-06166-6"
+        },
+        "sameAs": "https://doi.org/10.1038/s41586-023-06166-6"
+      },
+      "citation": "Villalba-Mouco, V. et al. (2023). Nature, 618, 550–556."
     }
     </script>
 </head>

--- a/research/north-africa-demographic-history-2024.html
+++ b/research/north-africa-demographic-history-2024.html
@@ -53,13 +53,49 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ScholarlyArticle",
-      "headline": "Modelling the Demographic History of Human North African Genomes Points to a Recent Soft Split Divergence Between Populations",
+      "@type": "Article",
+      "headline": "Amazigh and Arab populations diverged over 20,000 years ago",
+      "description": "Summary of Serradell et al. 2024 Genome Biology study: AI-driven modelling reveals Amazigh and Arab populations diverged over 20,000 years ago via a soft split demographic model.",
       "url": "https://northafricanorigins.com/research/north-africa-demographic-history-2024.html",
+      "mainEntityOfPage": "https://northafricanorigins.com/research/north-africa-demographic-history-2024.html",
       "inLanguage": "en",
-      "datePublished": "2024-07-30",
+      "datePublished": "2026-04-24",
       "dateModified": "2026-09-10",
-      "sameAs": "https://doi.org/10.1186/s13059-024-03341-4"
+      "author": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "isBasedOn": {
+        "@type": "ScholarlyArticle",
+        "@id": "https://doi.org/10.1186/s13059-024-03341-4",
+        "headline": "Modelling the Demographic History of Human North African Genomes Points to a Recent Soft Split Divergence Between Populations",
+        "datePublished": "2024-07-30",
+        "isPartOf": {
+          "@type": "Periodical",
+          "name": "Genome Biology"
+        },
+        "identifier": {
+          "@type": "PropertyValue",
+          "propertyID": "DOI",
+          "value": "10.1186/s13059-024-03341-4"
+        },
+        "sameAs": "https://doi.org/10.1186/s13059-024-03341-4"
+      },
+      "citation": "Serradell, J. M. et al. (2024). Genome Biology, 25, 201."
     }
     </script>
 </head>

--- a/research/north-africa-maternal-diversity-2026.html
+++ b/research/north-africa-maternal-diversity-2026.html
@@ -53,13 +53,49 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ScholarlyArticle",
-      "headline": "The North African Maternal Genetic Diversity Enriched by Historical Migrations",
+      "@type": "Article",
+      "headline": "North African maternal diversity, from 869 mitogenomes",
+      "description": "Summary of Boumajdi et al. 2026: 869 complete North African mitogenomes show a cohesive Maghreb core and historical female-mediated migrations.",
       "url": "https://northafricanorigins.com/research/north-africa-maternal-diversity-2026.html",
+      "mainEntityOfPage": "https://northafricanorigins.com/research/north-africa-maternal-diversity-2026.html",
       "inLanguage": "en",
-      "datePublished": "2026-03-12",
+      "datePublished": "2026-04-14",
       "dateModified": "2026-09-10",
-      "sameAs": "https://doi.org/10.1007/s00335-026-10209-4"
+      "author": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "isBasedOn": {
+        "@type": "ScholarlyArticle",
+        "@id": "https://doi.org/10.1007/s00335-026-10209-4",
+        "headline": "The North African Maternal Genetic Diversity Enriched by Historical Migrations",
+        "datePublished": "2026-03-12",
+        "isPartOf": {
+          "@type": "Periodical",
+          "name": "Mammalian Genome"
+        },
+        "identifier": {
+          "@type": "PropertyValue",
+          "propertyID": "DOI",
+          "value": "10.1007/s00335-026-10209-4"
+        },
+        "sameAs": "https://doi.org/10.1007/s00335-026-10209-4"
+      },
+      "citation": "Boumajdi, N. et al. (2026). Mammalian Genome."
     }
     </script>
 </head>

--- a/research/north-african-mitogenomes-2025.html
+++ b/research/north-african-mitogenomes-2025.html
@@ -53,13 +53,49 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ScholarlyArticle",
-      "headline": "The Origin of Modern North Africans as Depicted by a Massive Survey of Mitogenomes",
+      "@type": "Article",
+      "headline": "733 modern and 43 ancient mitogenomes",
+      "description": "Summary of Colombo et al. 2025: massive mitogenome survey of 733 modern and 43 ancient samples reveals H1 subclade patterns and female-mediated dispersals.",
       "url": "https://northafricanorigins.com/research/north-african-mitogenomes-2025.html",
+      "mainEntityOfPage": "https://northafricanorigins.com/research/north-african-mitogenomes-2025.html",
       "inLanguage": "en",
-      "datePublished": "2025-07-25",
+      "datePublished": "2026-02-13",
       "dateModified": "2026-09-10",
-      "sameAs": "https://doi.org/10.1038/s41598-025-12209-x"
+      "author": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "isBasedOn": {
+        "@type": "ScholarlyArticle",
+        "@id": "https://doi.org/10.1038/s41598-025-12209-x",
+        "headline": "The Origin of Modern North Africans as Depicted by a Massive Survey of Mitogenomes",
+        "datePublished": "2025-07-25",
+        "isPartOf": {
+          "@type": "Periodical",
+          "name": "Scientific Reports"
+        },
+        "identifier": {
+          "@type": "PropertyValue",
+          "propertyID": "DOI",
+          "value": "10.1038/s41598-025-12209-x"
+        },
+        "sameAs": "https://doi.org/10.1038/s41598-025-12209-x"
+      },
+      "citation": "Colombo, G. et al. (2025). Scientific Reports."
     }
     </script>
 </head>

--- a/research/punic-genetic-diversity-2025.html
+++ b/research/punic-genetic-diversity-2025.html
@@ -53,13 +53,49 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ScholarlyArticle",
-      "headline": "Punic People Were Genetically Diverse with Almost No Levantine Ancestors",
+      "@type": "Article",
+      "headline": "Punic people were genetically diverse, and barely Levantine",
+      "description": "Summary of Reich et al. 2025 (Nature): genome-wide data from 210 individuals shows high Punic-era diversity and major North African ancestry contributions.",
       "url": "https://northafricanorigins.com/research/punic-genetic-diversity-2025.html",
+      "mainEntityOfPage": "https://northafricanorigins.com/research/punic-genetic-diversity-2025.html",
       "inLanguage": "en",
-      "datePublished": "2025-04-23",
+      "datePublished": "2026-04-14",
       "dateModified": "2026-09-10",
-      "sameAs": "https://doi.org/10.1038/s41586-025-08913-3"
+      "author": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "North African Origins",
+        "url": "https://northafricanorigins.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://northafricanorigins.com/icon-512x512.png"
+        }
+      },
+      "isBasedOn": {
+        "@type": "ScholarlyArticle",
+        "@id": "https://doi.org/10.1038/s41586-025-08913-3",
+        "headline": "Punic People Were Genetically Diverse with Almost No Levantine Ancestors",
+        "datePublished": "2025-04-23",
+        "isPartOf": {
+          "@type": "Periodical",
+          "name": "Nature"
+        },
+        "identifier": {
+          "@type": "PropertyValue",
+          "propertyID": "DOI",
+          "value": "10.1038/s41586-025-08913-3"
+        },
+        "sameAs": "https://doi.org/10.1038/s41586-025-08913-3"
+      },
+      "citation": "Reich, D. et al. (2025). Nature, 643, 139-147."
     }
     </script>
 </head>


### PR DESCRIPTION
Was stacked on #96 (now merged); retargeted to `main`.

## What

Each research page's JSON-LD said the page **was** the paper: a `ScholarlyArticle` with the paper's title, the paper's date and `sameAs` pointing at the paper's DOI. Search engines and AI agents could read that as the site claiming to be the publisher of Nature papers, and couldn't tell the summary from the source.

The pages now say what they are:

```
Article                        ← this site's summary
  headline, description        ← the summary's own list title and meta description
  datePublished                ← when the summary was first added (git history)
  author, publisher            ← North African Origins, with logo
  isBasedOn: ScholarlyArticle  ← the paper
    @id / sameAs               ← https://doi.org/…
    headline, datePublished    ← the paper's title and publication date
    isPartOf: Periodical       ← the journal
    identifier                 ← DOI as PropertyValue
  citation                     ← the full citation text from the page
```

- **All 13 existing pages** were regenerated from facts already on each page and in `research.html`: the h1, kicker, DOI link, citation note and list title. Nothing was retyped. Each one's `dateModified`, "Last updated" and sitemap `lastmod` were bumped.
- **The scout:**
  - `article_ld()` builds the block for new pages, from Crossref facts plus the summary's title and description.
  - `validate` now parses the JSON-LD and checks the paper's date and DOI inside `isBasedOn`, instead of grepping the first `datePublished`/`sameAs`.
  - It stays one `<script>` block, so `render_page`'s swap still matches.

## Checked

- `scout.py validate --offline` passes on the 13 pages.
- Every JSON-LD block on the site parses.
- **End to end:** on a scratch copy, `scout.py apply` was run with a synthetic accepted paper.
  - The new page came out as `Article` → `isBasedOn` → `ScholarlyArticle`, with the right DOI, journal, dates and citation.
  - `llms.txt` gained the paper, and every count moved to "fourteen".
  - `validate --offline --check-changed` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015t4mnrJt1QGKZ56brKvpeh
